### PR TITLE
refactor(stylelint): resilience

### DIFF
--- a/.config/.lintstagedrc.js
+++ b/.config/.lintstagedrc.js
@@ -1,8 +1,8 @@
 export default {
 	'*.md': 'markdownlint -c .config/.markdown-lint.yml',
 	// In case that we're changing the stylelints configuration files content, we would need to validate it
-	'.stylelintrc.*': 'stylelint --validate',
-	'stylelint.config.*': 'stylelint --validate',
+	'.stylelintrc.*': 'stylelint --validate --allow-empty-input',
+	'stylelint.config.*': 'stylelint --validate --allow-empty-input',
 	// and elsewhere we don't, compare to https://github.com/stylelint/stylelint/pull/8009
 	'*.{css,scss}': 'stylelint --fix --allow-empty-input --no-validate',
 	'*.{js,ts,tsx,jsx,mjs,cjs}': 'xo --fix'

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -11,3 +11,4 @@ showcases/**/public/**
 packages/foundations/scripts/generate-icon-fonts/styles/**
 packages/foundations/scss/_normalize.scss
 packages/stylelint/test/**
+.stylelintrc.json


### PR DESCRIPTION
## Proposed changes

Regularly we don't want to lint the stylelint config file. But in case of any changes within these files, this might be the only file that is being defined to get linted by `stylelint` through `lint-staged` (which wouldn't work, as it doesn't contain CSS).

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (fix on existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
