### PR TITLE
refactor: we could just remove those depreacted rules

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -49,24 +49,6 @@
 				"ignoreAnnotations": ["default", "global"]
 			}
 		],
-		"declaration-property-value-no-unknown": true,
-		"@stylistic/block-opening-brace-space-before": null,
-		"@stylistic/color-hex-case": null,
-		"@stylistic/declaration-bang-space-after": null,
-		"@stylistic/declaration-bang-space-before": null,
-		"@stylistic/declaration-block-semicolon-newline-after": null,
-		"@stylistic/declaration-block-semicolon-space-before": null,
-		"@stylistic/declaration-block-trailing-semicolon": null,
-		"@stylistic/declaration-colon-space-after": null,
-		"@stylistic/declaration-colon-space-before": null,
-		"@stylistic/function-comma-space-after": null,
-		"@stylistic/function-parentheses-space-inside": null,
-		"@stylistic/indentation": null,
-		"@stylistic/media-feature-parentheses-space-inside": null,
-		"@stylistic/no-missing-end-of-source-newline": null,
-		"@stylistic/number-leading-zero": null,
-		"@stylistic/number-no-trailing-zeros": null,
-		"@stylistic/selector-list-comma-newline-after": null,
-		"@stylistic/string-quotes": null
+		"declaration-property-value-no-unknown": true
 	}
 }


### PR DESCRIPTION
## Proposed changes

"removing the deprecated rules from your configuration object", source "removing the deprecated rules from your configuration object", source https://github.com/stylelint/stylelint/blob/main/docs/migration-guide/to-15.md#deprecated-stylistic-rules

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (fix on existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
