### PR TITLE
refactor: let's not hide the first element in the select anymore

### DIFF
--- a/packages/components/src/components/select/select.lite.tsx
+++ b/packages/components/src/components/select/select.lite.tsx
@@ -224,7 +224,9 @@ export default function DBSelect(props: DBSelectProps) {
 				}
 				aria-describedby={state._descByIds}>
 				{/* Empty option for floating label */}
-				<option hidden></option>
+				<Show when={props.variant === 'floating' || props.placeholder}>
+					<option class="placeholder"></option>
+				</Show>
 				<Show when={props.options}>
 					<For each={props.options}>
 						{(option: DBSelectOptionType) => (

--- a/packages/components/src/components/select/select.scss
+++ b/packages/components/src/components/select/select.scss
@@ -76,7 +76,7 @@ $has-before-padding: calc(
 		);
 	}
 
-	&:has(> select option:checked:not([hidden])) {
+	&:has(> select option:checked:not(.placeholder)) {
 		[id$="-placeholder"] {
 			display: none;
 		}

--- a/packages/components/src/styles/internal/_form-components.scss
+++ b/packages/components/src/styles/internal/_form-components.scss
@@ -115,7 +115,7 @@ $check-border-size: min(#{variables.$db-border-height-2xs}, 2px);
 		&:has(
 				#{$selector}:focus-within,
 				#{$selector}:is(input, textarea):not(:placeholder-shown),
-				> select option:checked:not([hidden])
+				> select option:checked:not(.placeholder)
 			) {
 			label {
 				@extend %db-overwrite-font-size-2xs;


### PR DESCRIPTION
## Proposed changes

- it's inconsistent in between browsers (Safari would still display that `option[hidden]`)
- it's inconsistent and incorrect to regular `select`-HTML-elements, as those would actually mark the first `option` as checked as well, whereas this is actually the selected one (gets transmitted in form submits etc.)
- In case that somebody would like to use floating labels or `placeholder`, there should be an `option` that the users could set to "unselect" all selectable options, or in other words "reset" any other selection. We wouldn't provide this possibility at the moment anyhow.

Resolves https://github.com/db-ux-design-system/core-web/issues/4019

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (fix on existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
