### PR TITLE
feat: enable text of navigation-item to break into multiple lines

### DIFF
--- a/__snapshots__/navigation-item/showcase/chromium-highContrast/should-have-same-aria-snapshot/DBNavigationItem-should-have-same-aria-snapshot.yaml
+++ b/__snapshots__/navigation-item/showcase/chromium-highContrast/should-have-same-aria-snapshot/DBNavigationItem-should-have-same-aria-snapshot.yaml
@@ -46,3 +46,14 @@
   - list:
     - listitem:
       - link "Full"
+  - link "Wrap arrow_up_right\" / \""
+  - list:
+    - listitem:
+      - button "No Wrap (Default) chevron_right\" / \""
+  - list:
+    - listitem:
+      - text: x_placeholder" / "
+      - button "This is a very long text that is broken into multiple lines. chevron_right\" / \""
+  - list:
+    - listitem:
+      - button "This is a very long text that is broken into multiple lines. chevron_right\" / \""

--- a/__snapshots__/navigation-item/showcase/chromium/should-have-same-aria-snapshot/DBNavigationItem-should-have-same-aria-snapshot.yaml
+++ b/__snapshots__/navigation-item/showcase/chromium/should-have-same-aria-snapshot/DBNavigationItem-should-have-same-aria-snapshot.yaml
@@ -46,3 +46,14 @@
   - list:
     - listitem:
       - link "Full"
+  - link "Wrap arrow_up_right\" / \""
+  - list:
+    - listitem:
+      - button "No Wrap (Default) chevron_right\" / \""
+  - list:
+    - listitem:
+      - text: x_placeholder" / "
+      - button "This is a very long text that is broken into multiple lines. chevron_right\" / \""
+  - list:
+    - listitem:
+      - button "This is a very long text that is broken into multiple lines. chevron_right\" / \""

--- a/__snapshots__/navigation-item/showcase/firefox/should-have-same-aria-snapshot/DBNavigationItem-should-have-same-aria-snapshot.yaml
+++ b/__snapshots__/navigation-item/showcase/firefox/should-have-same-aria-snapshot/DBNavigationItem-should-have-same-aria-snapshot.yaml
@@ -45,3 +45,13 @@
   - list:
     - listitem:
       - link "Full"
+  - link "Wrap arrow_up_right\" / \""
+  - list:
+    - listitem:
+      - button "No Wrap (Default) chevron_right\" / \""
+  - list:
+    - listitem:
+      - button "This is a very long text that is broken into multiple lines. chevron_right\" / \""
+  - list:
+    - listitem:
+      - button "This is a very long text that is broken into multiple lines. chevron_right\" / \""

--- a/__snapshots__/navigation-item/showcase/mobile-chrome/should-have-same-aria-snapshot/DBNavigationItem-should-have-same-aria-snapshot.yaml
+++ b/__snapshots__/navigation-item/showcase/mobile-chrome/should-have-same-aria-snapshot/DBNavigationItem-should-have-same-aria-snapshot.yaml
@@ -46,3 +46,14 @@
   - list:
     - listitem:
       - link "Full"
+  - link "Wrap arrow_up_right\" / \""
+  - list:
+    - listitem:
+      - button "No Wrap (Default) chevron_right\" / \""
+  - list:
+    - listitem:
+      - text: x_placeholder" / "
+      - button "This is a very long text that is broken into multiple lines. chevron_right\" / \""
+  - list:
+    - listitem:
+      - button "This is a very long text that is broken into multiple lines. chevron_right\" / \""

--- a/__snapshots__/navigation-item/showcase/mobile-safari/should-have-same-aria-snapshot/DBNavigationItem-should-have-same-aria-snapshot.yaml
+++ b/__snapshots__/navigation-item/showcase/mobile-safari/should-have-same-aria-snapshot/DBNavigationItem-should-have-same-aria-snapshot.yaml
@@ -46,3 +46,14 @@
   - list:
     - listitem:
       - link "Full"
+  - link "Wrap arrow_up_right\" / \""
+  - list:
+    - listitem:
+      - button "No Wrap (Default) chevron_right\" / \""
+  - list:
+    - listitem:
+      - text: x_placeholder" / "
+      - button "This is a very long text that is broken into multiple lines. chevron_right\" / \""
+  - list:
+    - listitem:
+      - button "This is a very long text that is broken into multiple lines. chevron_right\" / \""

--- a/__snapshots__/navigation-item/showcase/webkit/should-have-same-aria-snapshot/DBNavigationItem-should-have-same-aria-snapshot.yaml
+++ b/__snapshots__/navigation-item/showcase/webkit/should-have-same-aria-snapshot/DBNavigationItem-should-have-same-aria-snapshot.yaml
@@ -46,3 +46,14 @@
   - list:
     - listitem:
       - link "Full"
+  - link "Wrap arrow_up_right\" / \""
+  - list:
+    - listitem:
+      - button "No Wrap (Default) chevron_right\" / \""
+  - list:
+    - listitem:
+      - text: x_placeholder" / "
+      - button "This is a very long text that is broken into multiple lines. chevron_right\" / \""
+  - list:
+    - listitem:
+      - button "This is a very long text that is broken into multiple lines. chevron_right\" / \""

--- a/packages/components/src/components/navigation-item/model.ts
+++ b/packages/components/src/components/navigation-item/model.ts
@@ -35,6 +35,11 @@ export type DBNavigationItemDefaultProps = {
 	 * This is for mobile navigation only, if it is set the sub-navigation is a static overlay
 	 */
 	subNavigationExpanded?: boolean | string;
+
+	/**
+	 * Determines whether the text should wrap when its parent container is too small, preventing overflow.
+	 */
+	wrap?: boolean | string;
 };
 
 export type DBNavigationItemProps = DBNavigationItemDefaultProps &

--- a/packages/components/src/components/navigation-item/navigation-item.lite.tsx
+++ b/packages/components/src/components/navigation-item/navigation-item.lite.tsx
@@ -116,6 +116,7 @@ export default function DBNavigationItem(props: DBNavigationItemProps) {
 			data-icon={props.icon}
 			data-hide-icon={getHideProp(props.showIcon)}
 			data-active={props.active}
+			data-wrap={getBooleanAsString(props.wrap)}
 			aria-disabled={getBooleanAsString(props.disabled)}>
 			<Show when={!state.hasSubNavigation}>
 				<Show when={props.text} else={props.children}>

--- a/packages/components/src/components/navigation-item/navigation-item.scss
+++ b/packages/components/src/components/navigation-item/navigation-item.scss
@@ -87,6 +87,15 @@
 	position: relative;
 	inline-size: auto;
 
+	&[data-wrap="true"] {
+		.db-navigation-item-expand-button {
+			&:is(button) {
+				white-space: normal;
+				text-align: start;
+			}
+		}
+	}
+
 	@include screen-sizes.screen("md", "max") {
 		&:not([data-width="full"]) {
 			.db-navigation-item-expand-button {

--- a/showcases/angular-showcase/src/app/components/navigation-item/navigation-item.component.html
+++ b/showcases/angular-showcase/src/app/components/navigation-item/navigation-item.component.html
@@ -31,32 +31,30 @@
 
 				@if (exampleProps?.areaPopup) {
 					<ng-container sub-navigation>
-						<ul>
-							<db-navigation-item
-								[icon]="exampleProps?.icon"
-								[showIcon]="exampleProps?.showIcon"
-							>
-								<ng-container *dbNavigationContent>
-									<a href="#">Test1</a>
-								</ng-container>
-							</db-navigation-item>
-							<db-navigation-item
-								[icon]="exampleProps?.icon"
-								[showIcon]="exampleProps?.showIcon"
-							>
-								<ng-container *dbNavigationContent>
-									<a href="#">Test2</a>
-								</ng-container>
-							</db-navigation-item>
-							<db-navigation-item
-								[icon]="exampleProps?.icon"
-								[showIcon]="exampleProps?.showIcon"
-							>
-								<ng-container *dbNavigationContent>
-									<a href="#">Test3</a>
-								</ng-container>
-							</db-navigation-item>
-						</ul>
+						<db-navigation-item
+							[icon]="exampleProps?.icon"
+							[showIcon]="exampleProps?.showIcon"
+						>
+							<ng-container *dbNavigationContent>
+								<a href="#">Test1</a>
+							</ng-container>
+						</db-navigation-item>
+						<db-navigation-item
+							[icon]="exampleProps?.icon"
+							[showIcon]="exampleProps?.showIcon"
+						>
+							<ng-container *dbNavigationContent>
+								<a href="#">Test2</a>
+							</ng-container>
+						</db-navigation-item>
+						<db-navigation-item
+							[icon]="exampleProps?.icon"
+							[showIcon]="exampleProps?.showIcon"
+						>
+							<ng-container *dbNavigationContent>
+								<a href="#">Test3</a>
+							</ng-container>
+						</db-navigation-item>
 					</ng-container>
 				}
 			</db-navigation-item>

--- a/showcases/angular-showcase/src/app/components/navigation-item/navigation-item.component.html
+++ b/showcases/angular-showcase/src/app/components/navigation-item/navigation-item.component.html
@@ -32,17 +32,26 @@
 				@if (exampleProps?.areaPopup) {
 					<ng-container sub-navigation>
 						<ul>
-							<db-navigation-item>
+							<db-navigation-item
+								[icon]="exampleProps?.icon"
+								[showIcon]="exampleProps?.showIcon"
+							>
 								<ng-container *dbNavigationContent>
 									<a href="#">Test1</a>
 								</ng-container>
 							</db-navigation-item>
-							<db-navigation-item>
+							<db-navigation-item
+								[icon]="exampleProps?.icon"
+								[showIcon]="exampleProps?.showIcon"
+							>
 								<ng-container *dbNavigationContent>
 									<a href="#">Test2</a>
 								</ng-container>
 							</db-navigation-item>
-							<db-navigation-item>
+							<db-navigation-item
+								[icon]="exampleProps?.icon"
+								[showIcon]="exampleProps?.showIcon"
+							>
 								<ng-container *dbNavigationContent>
 									<a href="#">Test3</a>
 								</ng-container>

--- a/showcases/angular-showcase/src/app/components/navigation-item/navigation-item.component.html
+++ b/showcases/angular-showcase/src/app/components/navigation-item/navigation-item.component.html
@@ -17,6 +17,7 @@
 				[width]="exampleProps?.width"
 				[disabled]="exampleProps?.disabled"
 				[active]="exampleProps?.active"
+				[wrap]="exampleProps?.wrap"
 				(click)="showAlert(exampleName)"
 			>
 				<ng-container *dbNavigationContent>

--- a/showcases/react-showcase/src/components/navigation-item/index.tsx
+++ b/showcases/react-showcase/src/components/navigation-item/index.tsx
@@ -12,7 +12,8 @@ const getNavigationItem = ({
 	active,
 	width,
 	areaPopup,
-	showIcon
+	showIcon,
+	wrap
 }: DBNavigationItemProps & { areaPopup: boolean }) => (
 	<ul className="nav-item-list">
 		<DBNavigationItem
@@ -25,6 +26,7 @@ const getNavigationItem = ({
 				alert(children.toString());
 			}}
 			showIcon={showIcon}
+			wrap={wrap}
 			subNavigation={
 				areaPopup && (
 					<ul>

--- a/showcases/react-showcase/src/components/navigation-item/index.tsx
+++ b/showcases/react-showcase/src/components/navigation-item/index.tsx
@@ -29,14 +29,14 @@ const getNavigationItem = ({
 			wrap={wrap}
 			subNavigation={
 				areaPopup && (
-					<ul>
+					<>
 						<DBNavigationItem icon={icon} showIcon={showIcon}>
 							<a href="#">Test1</a>
 						</DBNavigationItem>
 						<DBNavigationItem icon={icon} showIcon={showIcon}>
 							<a href="#">Test2</a>
 						</DBNavigationItem>
-					</ul>
+					</>
 				)
 			}>
 			{areaPopup ? children : <a href="#">{children}</a>}

--- a/showcases/react-showcase/src/components/navigation-item/index.tsx
+++ b/showcases/react-showcase/src/components/navigation-item/index.tsx
@@ -30,10 +30,10 @@ const getNavigationItem = ({
 			subNavigation={
 				areaPopup && (
 					<ul>
-						<DBNavigationItem>
+						<DBNavigationItem icon={icon} showIcon={showIcon}>
 							<a href="#">Test1</a>
 						</DBNavigationItem>
-						<DBNavigationItem>
+						<DBNavigationItem icon={icon} showIcon={showIcon}>
 							<a href="#">Test2</a>
 						</DBNavigationItem>
 					</ul>

--- a/showcases/shared/navigation-item.json
+++ b/showcases/shared/navigation-item.json
@@ -270,7 +270,9 @@
 						"name": "a",
 						"native": true,
 						"props": {
-							"href": "#"
+							"href": "#",
+							"icon": "x_placeholder",
+							"showIcon": true
 						},
 						"content": "True"
 					}

--- a/showcases/shared/navigation-item.json
+++ b/showcases/shared/navigation-item.json
@@ -234,5 +234,69 @@
 				]
 			}
 		]
+	},
+	{
+		"name": "Wrap",
+		"examples": [
+			{
+				"name": "No Wrap (Default)",
+				"props": {
+					"areaPopup": true
+				},
+				"children": [
+					{
+						"name": "a",
+						"native": true,
+						"props": {
+							"href": "#"
+						},
+						"content": "True"
+					}
+				]
+			},
+			{
+				"name": "This is a very long text that is broken into multiple lines.",
+				"props": {
+					"areaPopup": true,
+					"icon": "x_placeholder",
+					"showIcon": true,
+					"wrap": true
+				},
+				"style": {
+					"width": "200px"
+				},
+				"children": [
+					{
+						"name": "a",
+						"native": true,
+						"props": {
+							"href": "#"
+						},
+						"content": "True"
+					}
+				]
+			},
+			{
+				"name": "This is a very long text that is broken into multiple lines.",
+				"props": {
+					"areaPopup": true,
+					"wrap": true
+				},
+				"style": {
+					"width": "200px"
+				},
+				"slot": "sub-navigation",
+				"children": [
+					{
+						"name": "a",
+						"native": true,
+						"props": {
+							"href": "#"
+						},
+						"content": "True"
+					}
+				]
+			}
+		]
 	}
 ]

--- a/showcases/vue-showcase/src/components/navigation-item/NavigationItem.vue
+++ b/showcases/vue-showcase/src/components/navigation-item/NavigationItem.vue
@@ -31,12 +31,18 @@ const log = (exampleName?: string) => {
 					<template v-if="exampleProps?.areaPopup" #sub-navigation>
 						<ul>
 							<DBNavigationItem
+								:icon="exampleProps?.icon"
+								:showIcon="exampleProps?.showIcon"
 								><a href="#">Test1</a></DBNavigationItem
 							>
 							<DBNavigationItem
+								:icon="exampleProps?.icon"
+								:showIcon="exampleProps?.showIcon"
 								><a href="#">Test2</a></DBNavigationItem
 							>
 							<DBNavigationItem
+								:icon="exampleProps?.icon"
+								:showIcon="exampleProps?.showIcon"
 								><a href="#">Test3</a></DBNavigationItem
 							>
 						</ul>

--- a/showcases/vue-showcase/src/components/navigation-item/NavigationItem.vue
+++ b/showcases/vue-showcase/src/components/navigation-item/NavigationItem.vue
@@ -29,23 +29,21 @@ const log = (exampleName?: string) => {
 					@click="log(exampleName)"
 				>
 					<template v-if="exampleProps?.areaPopup" #sub-navigation>
-						<ul>
-							<DBNavigationItem
-								:icon="exampleProps?.icon"
-								:showIcon="exampleProps?.showIcon"
-								><a href="#">Test1</a></DBNavigationItem
-							>
-							<DBNavigationItem
-								:icon="exampleProps?.icon"
-								:showIcon="exampleProps?.showIcon"
-								><a href="#">Test2</a></DBNavigationItem
-							>
-							<DBNavigationItem
-								:icon="exampleProps?.icon"
-								:showIcon="exampleProps?.showIcon"
-								><a href="#">Test3</a></DBNavigationItem
-							>
-						</ul>
+						<DBNavigationItem
+							:icon="exampleProps?.icon"
+							:showIcon="exampleProps?.showIcon"
+							><a href="#">Test1</a></DBNavigationItem
+						>
+						<DBNavigationItem
+							:icon="exampleProps?.icon"
+							:showIcon="exampleProps?.showIcon"
+							><a href="#">Test2</a></DBNavigationItem
+						>
+						<DBNavigationItem
+							:icon="exampleProps?.icon"
+							:showIcon="exampleProps?.showIcon"
+							><a href="#">Test3</a></DBNavigationItem
+						>
 					</template>
 					<template v-if="exampleProps?.areaPopup">
 						{{ exampleName }}

--- a/showcases/vue-showcase/src/components/navigation-item/NavigationItem.vue
+++ b/showcases/vue-showcase/src/components/navigation-item/NavigationItem.vue
@@ -25,6 +25,7 @@ const log = (exampleName?: string) => {
 					:disabled="exampleProps?.disabled"
 					:active="exampleProps?.active"
 					:areaPopup="exampleProps?.areaPopup"
+					:wrap="exampleProps?.wrap"
 					@click="log(exampleName)"
 				>
 					<template v-if="exampleProps?.areaPopup" #sub-navigation>


### PR DESCRIPTION
## Proposed changes

* Enable text of navigation-item to break into multiple lines
* Added showcase that demonstrates the use of multi-line text in navigation items.
* Adapted snapshots
* Fixed incorrect padding in showcases for navigations with sub-items

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (fix on existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->
