### PR TITLE
fix(DB Neo): removed local font references

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4035,11 +4035,12 @@
       }
     },
     "node_modules/@db-ux/db-theme-fonts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@db-ux/db-theme-fonts/-/db-theme-fonts-2.0.0.tgz",
-      "integrity": "sha512-+xkKKkfaTxY68NXt4bFaP/QtKBhxKvP37Urs37pYsDohZqSPaKhmejkdyfGeje2orKsD7HTCk43rhVM5LPRr2w==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@db-ux/db-theme-fonts/-/db-theme-fonts-2.0.1.tgz",
+      "integrity": "sha512-Wbrovff+GiZDF5vYoHQNhQyEA+8akqY/qihvm1f4Jtn9loBuUnRWYWXYFupBY8nC2mPmzSwm00IxdP/PYGs4TA==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "SEE LICENSE IN LICENSE",
       "peer": true
     },
     "node_modules/@db-ux/db-theme-icons": {
@@ -40723,7 +40724,7 @@
     },
     "showcases/next-showcase": {
       "dependencies": {
-        "next": "*",
+        "next": "latest",
         "react": "18.3.1",
         "react-dom": "18.3.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@axe-core/playwright": "^4.10.1",
         "@commitlint/cli": "19.8.0",
         "@commitlint/config-conventional": "19.8.0",
-        "@db-ux/db-theme": "2.0.1",
+        "@db-ux/db-theme": "2.0.2",
         "@double-great/stylelint-a11y": "3.0.4",
         "@guidepup/guidepup": "0.24.0",
         "@guidepup/playwright": "^0.14.2",
@@ -4023,13 +4023,13 @@
       "link": true
     },
     "node_modules/@db-ux/db-theme": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@db-ux/db-theme/-/db-theme-2.0.1.tgz",
-      "integrity": "sha512-tZDVOUnezTgXdxw0bud2zdl+UT+AoDjUWfxFG/+A2IgVAA/L+PbTzvLhfHudOW7/ANHEN9rz2MGY57oVlbSySw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@db-ux/db-theme/-/db-theme-2.0.2.tgz",
+      "integrity": "sha512-V+7iaNvo4BGgjFJaQahtGANn1SoM2c3yXgkZj4lDFGkBHfMpRYNMM2sEO+nJd81C62FwKrgeIXL+ijibyTY3sQ==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE",
       "peerDependencies": {
-        "@db-ux/db-theme-fonts": "^2.0.0",
+        "@db-ux/db-theme-fonts": "^2.0.1",
         "@db-ux/db-theme-icons": "^1.0.2",
         "@db-ux/db-theme-illustrative-icons": "^1.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@axe-core/playwright": "^4.10.1",
     "@commitlint/cli": "19.8.0",
     "@commitlint/config-conventional": "19.8.0",
-    "@db-ux/db-theme": "2.0.1",
+    "@db-ux/db-theme": "2.0.2",
     "@double-great/stylelint-a11y": "3.0.4",
     "@guidepup/guidepup": "0.24.0",
     "@guidepup/playwright": "^0.14.2",
@@ -110,7 +110,6 @@
     "zone.js": "~0.15.0"
   },
   "overrides": {
-    "@db-ux/db-theme-fonts": "2.0.1",
     "cross-spawn": "~7.0.5",
     "vite": "$vite"
   },

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "zone.js": "~0.15.0"
   },
   "overrides": {
+    "@db-ux/db-theme-fonts": "2.0.1",
     "cross-spawn": "~7.0.5",
     "vite": "$vite"
   },


### PR DESCRIPTION
## Proposed changes

The new DB Neo Screen font seems to get rendered differently when referenced from locally installed files vs. the web fonts.

Resolves https://github.com/db-ux-design-system/core-web/issues/4075

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (fix on existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
