### PR TITLE
feat: set border- and label-color for in/valid state of textarea, custom select and input

### DIFF
--- a/packages/components/src/styles/internal/_form-components.scss
+++ b/packages/components/src/styles/internal/_form-components.scss
@@ -153,6 +153,24 @@ $db-min-inline-size: var(
 				}
 			}
 		}
+
+		@each $state, $variant in (valid: successful, invalid: critical) {
+			&[data-custom-validity="#{$state}"] > label,
+			&:has(> #{$selector}[data-custom-validity="#{$state}"]) > label {
+				color: var(--db-#{$variant}-on-bg-basic-emphasis-70-default);
+			}
+
+			@if ($selector == textarea) {
+				&:has(> #{$selector}[data-custom-validity="#{$state}"]) {
+					&::before,
+					&::after {
+						// necessary to force this override over the placeholder-content mixin's ::before rule
+						// to avoid the label to influence the border of the textarea
+						content: none !important;
+					}
+				}
+			}
+		}
 	}
 }
 
@@ -368,6 +386,16 @@ $input-valid-types:
 				--db-textarea-read-only,
 				#{colors.$db-adaptive-bg-basic-level-1-default}
 			) !important;
+		}
+
+		&:is(textarea) {
+			@each $state, $variant in (valid: successful, invalid: critical) {
+				&[data-custom-validity="#{$state}"] {
+					border: var(--db-border-width-3xs)
+						solid
+						var(--db-#{$variant}-on-bg-basic-emphasis-70-default);
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
## Proposed changes

* set border of textarea to corresponding color when in/valid state is set
* set floating label color of textarea, input and custom select to corresponding color when in/valid state is set

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (fix on existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
