### PR TITLE
Fix patternhub warnings

### DIFF
--- a/packages/components/src/components/select/select.lite.tsx
+++ b/packages/components/src/components/select/select.lite.tsx
@@ -236,6 +236,7 @@ export default function DBSelect(props: DBSelectProps) {
 									when={option.options}
 									else={
 										<option
+											key={option.value.toString()}
 											value={option.value}
 											disabled={option.disabled}
 											selected={option.selected}>

--- a/showcases/shared/tag.json
+++ b/showcases/shared/tag.json
@@ -189,7 +189,7 @@
 						"native": true,
 						"content": "Interactive Checkbox",
 						"props": {
-							"for": "checkbox01"
+							"htmlFor": "checkbox01"
 						},
 						"children": [
 							{
@@ -216,7 +216,7 @@
 						"native": true,
 						"content": "Interactive Radio 1",
 						"props": {
-							"for": "radio01"
+							"htmlFor": "radio01"
 						},
 						"children": [
 							{
@@ -244,7 +244,7 @@
 						"native": true,
 						"content": "Interactive Radio 2",
 						"props": {
-							"for": "radio02"
+							"htmlFor": "radio02"
 						},
 						"children": [
 							{
@@ -277,7 +277,7 @@
 						"native": true,
 						"content": "Interactive Checkbox",
 						"props": {
-							"for": "checkbox02"
+							"htmlFor": "checkbox02"
 						},
 						"children": [
 							{
@@ -296,7 +296,7 @@
 				"name": "True",
 				"props": {
 					"component": "checkbox",
-					"checked": true
+					"defaultChecked": true
 				},
 				"children": [
 					{
@@ -304,14 +304,14 @@
 						"native": true,
 						"content": "Interactive Checkbox",
 						"props": {
-							"for": "checkbox03"
+							"htmlFor": "checkbox03"
 						},
 						"children": [
 							{
 								"name": "input",
 								"native": true,
 								"props": {
-									"checked": true,
+									"defaultChecked": true,
 									"id": "checkbox03",
 									"type": "checkbox"
 								}
@@ -337,7 +337,7 @@
 						"native": true,
 						"content": "Interactive Checkbox",
 						"props": {
-							"for": "checkbox02"
+							"htmlFor": "checkbox02"
 						},
 						"children": [
 							{
@@ -364,14 +364,14 @@
 						"native": true,
 						"content": "Interactive Checkbox",
 						"props": {
-							"for": "checkbox04"
+							"htmlFor": "checkbox04"
 						},
 						"children": [
 							{
 								"name": "input",
 								"native": true,
 								"props": {
-									"checked": true,
+									"defaultChecked": true,
 									"disabled": true,
 									"id": "checkbox04",
 									"type": "checkbox"
@@ -430,7 +430,7 @@
 				"name": "True",
 				"props": {
 					"icon": "x_placeholder",
-					"content": true
+					"content": "true"
 				}
 			}
 		]
@@ -450,7 +450,7 @@
 						"native": true,
 						"content": "Interactive Checkbox",
 						"props": {
-							"for": "checkbox099"
+							"htmlFor": "checkbox099"
 						},
 						"children": [
 							{
@@ -475,7 +475,7 @@
 						"native": true,
 						"content": "Interactive Checkbox",
 						"props": {
-							"for": "checkbox099"
+							"htmlFor": "checkbox099"
 						},
 						"children": [
 							{
@@ -555,7 +555,7 @@
 						"native": true,
 						"content": "Interactive Checkbox",
 						"props": {
-							"for": "checkbox05"
+							"htmlFor": "checkbox05"
 						},
 						"children": [
 							{
@@ -582,7 +582,7 @@
 						"native": true,
 						"content": "Interactive Radio 3",
 						"props": {
-							"for": "radio03"
+							"htmlFor": "radio03"
 						},
 						"children": [
 							{
@@ -612,7 +612,7 @@
 						"native": true,
 						"content": "Interactive Radio 4",
 						"props": {
-							"for": "radio04"
+							"htmlFor": "radio04"
 						},
 						"children": [
 							{


### PR DESCRIPTION
## Proposed changes

* Boolean-as-content warnings
Changed content: true flags in tag variants to a string ("true"), that <db-tag> no longer receives raw booleans as children.

* Controlled vs. uncontrolled inputs
Replaced checked: true with defaultChecked: true to remove the “missing onChange handler” warning.

* Label for → htmlFor
Updated <label> prop from "for": "…” to "htmlFor": "…” so that React creates the correct htmlFor attribute instead of the invalid for.

* List key warnings
Added key props to <option> elements rendered inside <select> because of React’s requirement for unique keys.

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (fix on existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


