### PR TITLE
feat: add property `requiredAnnotation` to disable visual indicator (`*`) for semantically marked required form elements

### DIFF
--- a/packages/components/src/components/checkbox/checkbox.lite.tsx
+++ b/packages/components/src/components/checkbox/checkbox.lite.tsx
@@ -8,7 +8,7 @@ import {
 	useStore,
 	useTarget
 } from '@builder.io/mitosis';
-import { DBCheckboxProps, DBCheckboxState } from './model';
+
 import {
 	DEFAULT_INVALID_MESSAGE,
 	DEFAULT_INVALID_MESSAGE_ID_SUFFIX,
@@ -18,19 +18,21 @@ import {
 } from '../../shared/constants';
 import { ChangeEvent, InteractionEvent } from '../../shared/model';
 import {
-	handleFrameworkEventAngular,
-	handleFrameworkEventVue
-} from '../../utils/form-components';
-import DBInfotext from '../infotext/infotext.lite';
-import {
 	cls,
 	delay,
 	getBoolean,
+	getBooleanAsString,
 	getHideProp,
 	hasVoiceOver,
 	stringPropVisible,
 	uuid
 } from '../../utils';
+import {
+	handleFrameworkEventAngular,
+	handleFrameworkEventVue
+} from '../../utils/form-components';
+import DBInfotext from '../infotext/infotext.lite';
+import { DBCheckboxProps, DBCheckboxState } from './model';
 
 useMetadata({
 	angular: {
@@ -192,6 +194,10 @@ export default function DBCheckbox(props: DBCheckboxProps) {
 					disabled={getBoolean(props.disabled, 'disabled')}
 					value={props.value}
 					required={getBoolean(props.required, 'required')}
+					{...(getBooleanAsString(props.requiredAnnotation) ===
+					'false'
+						? { 'data-required-icon': 'false' }
+						: {})}
 					onChange={(event: ChangeEvent<HTMLInputElement>) =>
 						state.handleChange(event)
 					}

--- a/packages/components/src/components/custom-select/custom-select.lite.tsx
+++ b/packages/components/src/components/custom-select/custom-select.lite.tsx
@@ -10,23 +10,7 @@ import {
 	useStore,
 	useTarget
 } from '@builder.io/mitosis';
-import {
-	CustomSelectOptionType,
-	DBCustomSelectProps,
-	DBCustomSelectState
-} from './model';
-import {
-	cls,
-	delay,
-	getBoolean,
-	getBooleanAsString,
-	getHideProp,
-	getOptionKey,
-	getSearchInput,
-	hasVoiceOver,
-	stringPropVisible,
-	uuid
-} from '../../utils';
+
 import {
 	DEFAULT_CLOSE_BUTTON,
 	DEFAULT_INVALID_MESSAGE,
@@ -43,21 +27,38 @@ import {
 	DEFAULT_VALID_MESSAGE_ID_SUFFIX
 } from '../../shared/constants';
 import { ChangeEvent, ClickEvent } from '../../shared/model';
-import DBCustomSelectList from '../custom-select-list/custom-select-list.lite';
-import DBCustomSelectListItem from '../custom-select-list-item/custom-select-list-item.lite';
-import DBCustomSelectDropdown from '../custom-select-dropdown/custom-select-dropdown.lite';
-import DBInfotext from '../infotext/infotext.lite';
-import DBTag from '../tag/tag.lite';
-import DBButton from '../button/button.lite';
-import DBTooltip from '../tooltip/tooltip.lite';
+import {
+	cls,
+	delay,
+	getBoolean,
+	getBooleanAsString,
+	getHideProp,
+	getOptionKey,
+	getSearchInput,
+	hasVoiceOver,
+	stringPropVisible,
+	uuid
+} from '../../utils';
+import { DocumentClickListener } from '../../utils/document-click-listener';
+import { DocumentScrollListener } from '../../utils/document-scroll-listener';
+import { handleFixedDropdown } from '../../utils/floating-components';
 import {
 	handleFrameworkEventAngular,
 	handleFrameworkEventVue
 } from '../../utils/form-components';
+import DBButton from '../button/button.lite';
+import DBCustomSelectDropdown from '../custom-select-dropdown/custom-select-dropdown.lite';
+import DBCustomSelectListItem from '../custom-select-list-item/custom-select-list-item.lite';
+import DBCustomSelectList from '../custom-select-list/custom-select-list.lite';
+import DBInfotext from '../infotext/infotext.lite';
 import DBInput from '../input/input.lite';
-import { DocumentClickListener } from '../../utils/document-click-listener';
-import { DocumentScrollListener } from '../../utils/document-scroll-listener';
-import { handleFixedDropdown } from '../../utils/floating-components';
+import DBTag from '../tag/tag.lite';
+import DBTooltip from '../tooltip/tooltip.lite';
+import {
+	CustomSelectOptionType,
+	DBCustomSelectProps,
+	DBCustomSelectState
+} from './model';
 
 useMetadata({
 	angular: {
@@ -787,6 +788,9 @@ export default function DBCustomSelect(props: DBCustomSelectProps) {
 					: props.variant
 			}
 			data-required={getBooleanAsString(props.required)}
+			{...(getBooleanAsString(props.requiredAnnotation) === 'false'
+				? { 'data-required-icon': 'false' }
+				: {})}
 			data-placement={props.placement}
 			data-selected-type={props.multiple ? props.selectedType : 'text'}
 			data-hide-label={getHideProp(props.showLabel)}

--- a/packages/components/src/components/input/input.lite.tsx
+++ b/packages/components/src/components/input/input.lite.tsx
@@ -9,19 +9,7 @@ import {
 	useStore,
 	useTarget
 } from '@builder.io/mitosis';
-import {
-	cls,
-	delay,
-	getBoolean,
-	getHideProp,
-	getNumber,
-	hasVoiceOver,
-	isArrayOfStrings,
-	stringPropVisible,
-	uuid,
-	getInputValue
-} from '../../utils';
-import { DBInputProps, DBInputState } from './model';
+
 import {
 	DEFAULT_DATALIST_ID_SUFFIX,
 	DEFAULT_INVALID_MESSAGE,
@@ -38,11 +26,25 @@ import {
 	InteractionEvent,
 	ValueLabelType
 } from '../../shared/model';
-import DBInfotext from '../infotext/infotext.lite';
+import {
+	cls,
+	delay,
+	getBoolean,
+	getBooleanAsString,
+	getHideProp,
+	getInputValue,
+	getNumber,
+	hasVoiceOver,
+	isArrayOfStrings,
+	stringPropVisible,
+	uuid
+} from '../../utils';
 import {
 	handleFrameworkEventAngular,
 	handleFrameworkEventVue
 } from '../../utils/form-components';
+import DBInfotext from '../infotext/infotext.lite';
+import { DBInputProps, DBInputState } from './model';
 
 useMetadata({
 	angular: {
@@ -215,6 +217,9 @@ export default function DBInput(props: DBInputProps) {
 				placeholder={props.placeholder ?? DEFAULT_PLACEHOLDER}
 				disabled={getBoolean(props.disabled, 'disabled')}
 				required={getBoolean(props.required, 'required')}
+				{...(getBooleanAsString(props.requiredAnnotation) === 'false'
+					? { 'data-required-icon': 'false' }
+					: {})}
 				step={getNumber(props.step)}
 				value={props.value ?? state._value}
 				maxLength={getNumber(props.maxLength, props.maxlength)}

--- a/packages/components/src/components/radio/radio.lite.tsx
+++ b/packages/components/src/components/radio/radio.lite.tsx
@@ -8,13 +8,20 @@ import {
 	useStore,
 	useTarget
 } from '@builder.io/mitosis';
-import { DBRadioProps, DBRadioState } from './model';
-import { cls, getBoolean, getHideProp, uuid } from '../../utils';
+
 import { ChangeEvent, InteractionEvent } from '../../shared/model';
+import {
+	cls,
+	getBoolean,
+	getBooleanAsString,
+	getHideProp,
+	uuid
+} from '../../utils';
 import {
 	handleFrameworkEventAngular,
 	handleFrameworkEventVue
 } from '../../utils/form-components';
+import { DBRadioProps, DBRadioState } from './model';
 
 useMetadata({
 	angular: {
@@ -81,6 +88,9 @@ export default function DBRadio(props: DBRadioProps) {
 				aria-describedby={props.describedbyid ?? props.ariaDescribedBy}
 				value={props.value}
 				required={getBoolean(props.required, 'required')}
+				{...(getBooleanAsString(props.requiredAnnotation) === 'false'
+					? { 'data-required-icon': 'false' }
+					: {})}
 				onChange={(event: ChangeEvent<HTMLInputElement>) =>
 					state.handleChange(event)
 				}

--- a/packages/components/src/components/select/select.lite.tsx
+++ b/packages/components/src/components/select/select.lite.tsx
@@ -9,17 +9,7 @@ import {
 	useStore,
 	useTarget
 } from '@builder.io/mitosis';
-import { DBSelectOptionType, DBSelectProps, DBSelectState } from './model';
-import {
-	cls,
-	delay,
-	getBoolean,
-	getHideProp,
-	getOptionKey,
-	hasVoiceOver,
-	stringPropVisible,
-	uuid
-} from '../../utils';
+
 import {
 	DEFAULT_INVALID_MESSAGE,
 	DEFAULT_INVALID_MESSAGE_ID_SUFFIX,
@@ -29,7 +19,6 @@ import {
 	DEFAULT_VALID_MESSAGE,
 	DEFAULT_VALID_MESSAGE_ID_SUFFIX
 } from '../../shared/constants';
-import DBInfotext from '../infotext/infotext.lite';
 import {
 	ChangeEvent,
 	ClickEvent,
@@ -37,9 +26,22 @@ import {
 	InteractionEvent
 } from '../../shared/model';
 import {
+	cls,
+	delay,
+	getBoolean,
+	getBooleanAsString,
+	getHideProp,
+	getOptionKey,
+	hasVoiceOver,
+	stringPropVisible,
+	uuid
+} from '../../utils';
+import {
 	handleFrameworkEventAngular,
 	handleFrameworkEventVue
 } from '../../utils/form-components';
+import DBInfotext from '../infotext/infotext.lite';
+import { DBSelectOptionType, DBSelectProps, DBSelectState } from './model';
 
 useMetadata({
 	angular: {
@@ -204,6 +206,9 @@ export default function DBSelect(props: DBSelectProps) {
 				data-custom-validity={props.validation}
 				ref={_ref}
 				required={getBoolean(props.required, 'required')}
+				{...(getBooleanAsString(props.requiredAnnotation) === 'false'
+					? { 'data-required-icon': 'false' }
+					: {})}
 				disabled={getBoolean(props.disabled, 'disabled')}
 				id={state._id}
 				name={props.name}

--- a/packages/components/src/components/switch/switch.lite.tsx
+++ b/packages/components/src/components/switch/switch.lite.tsx
@@ -8,7 +8,8 @@ import {
 	useStore,
 	useTarget
 } from '@builder.io/mitosis';
-import { DBSwitchProps, DBSwitchState } from './model';
+
+import { ChangeEvent, InteractionEvent } from '../../shared/model';
 import {
 	cls,
 	getBoolean,
@@ -16,11 +17,11 @@ import {
 	getHideProp,
 	uuid
 } from '../../utils';
-import { ChangeEvent, InteractionEvent } from '../../shared/model';
 import {
 	handleFrameworkEventAngular,
 	handleFrameworkEventVue
 } from '../../utils/form-components';
+import { DBSwitchProps, DBSwitchState } from './model';
 
 useMetadata({
 	angular: {
@@ -99,6 +100,9 @@ export default function DBSwitch(props: DBSwitchProps) {
 				data-custom-validity={props.validation}
 				name={props.name}
 				required={getBoolean(props.required, 'required')}
+				{...(getBooleanAsString(props.requiredAnnotation) === 'false'
+					? { 'data-required-icon': 'false' }
+					: {})}
 				data-aid-icon={props.icon}
 				data-aid-icon-after={props.iconAfter}
 				onChange={(event: ChangeEvent<HTMLInputElement>) =>

--- a/packages/components/src/components/textarea/textarea.lite.tsx
+++ b/packages/components/src/components/textarea/textarea.lite.tsx
@@ -8,18 +8,7 @@ import {
 	useStore,
 	useTarget
 } from '@builder.io/mitosis';
-import { DBTextareaProps, DBTextareaState } from './model';
-import DBInfotext from '../infotext/infotext.lite';
-import {
-	cls,
-	delay,
-	getBoolean,
-	getHideProp,
-	getNumber,
-	hasVoiceOver,
-	stringPropVisible,
-	uuid
-} from '../../utils';
+
 import {
 	DEFAULT_INVALID_MESSAGE,
 	DEFAULT_INVALID_MESSAGE_ID_SUFFIX,
@@ -32,9 +21,22 @@ import {
 } from '../../shared/constants';
 import { ChangeEvent, InputEvent, InteractionEvent } from '../../shared/model';
 import {
+	cls,
+	delay,
+	getBoolean,
+	getBooleanAsString,
+	getHideProp,
+	getNumber,
+	hasVoiceOver,
+	stringPropVisible,
+	uuid
+} from '../../utils';
+import {
 	handleFrameworkEventAngular,
 	handleFrameworkEventVue
 } from '../../utils/form-components';
+import DBInfotext from '../infotext/infotext.lite';
+import { DBTextareaProps, DBTextareaState } from './model';
 
 useMetadata({
 	angular: {
@@ -183,6 +185,9 @@ export default function DBTextarea(props: DBTextareaProps) {
 				data-hide-resizer={getHideProp(props.showResizer ?? true)}
 				disabled={getBoolean(props.disabled, 'disabled')}
 				required={getBoolean(props.required, 'required')}
+				{...(getBooleanAsString(props.requiredAnnotation) === 'false'
+					? { 'data-required-icon': 'false' }
+					: {})}
 				readOnly={
 					getBoolean(props.readOnly, 'readOnly') ||
 					getBoolean(props.readonly, 'readonly')

--- a/packages/components/src/shared/model.ts
+++ b/packages/components/src/shared/model.ts
@@ -254,11 +254,21 @@ export type EmphasisProps = {
 export const ValidationList = ['invalid', 'valid', 'no-validation'] as const;
 export type ValidationType = (typeof ValidationList)[number];
 
+/**
+ * Properties to control the required state and its visual annotation for input components.
+ */
 export type RequiredProps = {
 	/**
 	 * When the required attribute specified, the user will be required to fill the form element before submitting the form.
+	 * The form element will be marked semantically as required and by default also visually with an asterisk '*' next to the label (unless the property `requiredAnnotation` is also set with the value `false`).
 	 */
 	required?: boolean | string;
+	/**
+	 * This attribute allows to specify whether a form field which is marked as required will show a visual indicator (an asterisk '*').
+	 * It allows to prevent adding the visual indicator but still keep the field semantically required by setting its value to `false`.
+	 * By default, its value is `true`, so the asterisk is shown when `required` is set.
+	 */
+	requiredAnnotation?: boolean | string;
 };
 export type ShowLabelProps = {
 	/**

--- a/packages/components/src/styles/internal/_form-components.scss
+++ b/packages/components/src/styles/internal/_form-components.scss
@@ -279,8 +279,8 @@ $input-valid-types:
 }
 
 @mixin set-required-label($selector) {
-	&:has(#{$selector}:required),
-	&[data-required="true"] {
+	&:has(#{$selector}:required):not([data-required-icon="false"]),
+	&[data-required="true"]:not([data-required-icon="false"]) {
 		&:is(label),
 		> label {
 			&::after {


### PR DESCRIPTION
## Proposed changes

add property `requiredAnnotation` to disable visual indicator (`*`) for semantically marked required form elements

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (fix on existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

closes #4197 / https://github.com/db-ux-design-system/core-team/issues/580
