### PR TITLE
refactor: font generation to use execFile for security

### DIFF
--- a/packages/foundations/assets/fonts/generate-eu-fonts.ts
+++ b/packages/foundations/assets/fonts/generate-eu-fonts.ts
@@ -1,5 +1,5 @@
 import { glob } from 'glob';
-import { exec } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 
 import { dirname } from 'path';
@@ -8,12 +8,16 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename).replaceAll('\\', '/');
 
-const execAsync = promisify(exec);
+// Security: Using execFile instead of exec to eliminate shell injection risks
+// execFile directly executes the binary without involving a shell
+const execFileAsync = promisify(execFile);
 
 const generateFonts = async () => {
 	console.log('Generating EU fonts...');
 	try {
-		await execAsync('pyftsubset --help');
+		// Security: Using array arguments instead of concatenated string
+		// This prevents shell interpretation of special characters
+		await execFileAsync('pyftsubset', ['--help']);
 	} catch (e) {
 		console.warn(
 			'You need to install pyftsubset. Check packages/foundations/assets/fonts/README.md for more information.'
@@ -22,19 +26,28 @@ const generateFonts = async () => {
 
 	try {
 		const files = await glob(`${__dirname}/*.ttf`);
-		const commands = files.map((file) =>
-			[
-				'pyftsubset',
+
+		for (const file of files) {
+			// Security: Validate that the file is within the expected directory
+			// and has the expected extension to prevent path traversal attacks
+			if (!file.startsWith(__dirname) || !file.endsWith('.ttf')) {
+				console.warn(`Skipping potentially unsafe file path: ${file}`);
+				continue;
+			}
+
+			// Security: Arguments are passed as separate array elements
+			// No shell concatenation means no risk of command injection
+			const args = [
 				file,
 				'--layout-features=*',
 				'--flavor=woff2',
 				`--unicodes-file=${__dirname}/unicode-eu.txt`,
 				`--output-file=${file.replace('.ttf', '-EU.woff2')}`
-			].join(' ')
-		);
+			];
 
-		for (const command of commands) {
-			const { stdout, stderr } = await execAsync(command);
+			// Security: execFile provides better performance and type safety
+			// as it doesn't spawn a shell process
+			const { stdout, stderr } = await execFileAsync('pyftsubset', args);
 			if (stdout) console.log(`stdout: ${stdout}`);
 			if (stderr) console.error(`stderr: ${stderr}`);
 		}


### PR DESCRIPTION
## Proposed changes

Replaced usage of exec with execFile to prevent shell injection risks when running pyftsubset. Arguments are now passed as arrays, and file paths are validated to avoid path traversal attacks. Improves security and reliability of font generation script.

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improvements to existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
