### PR TITLE
fix: annoying unformatted document on localhost

### DIFF
--- a/packages/foundations/package.json
+++ b/packages/foundations/package.json
@@ -37,6 +37,7 @@
     "dev": "vite --open",
     "generate:fonts": "tsx assets/fonts/generate-eu-fonts.ts",
     "generate:icons": "tsx scripts/local/generate-icon-font.ts",
+    "postcopy-prepare:icon-overview": "prettier dev/icons.html --write",
     "prebuild": "npm-run-all copy-prepare:*",
     "predev": "npm-run-all copy-prepare:*",
     "prestart": "npm-run-all copy-prepare:*",

--- a/packages/foundations/scripts/local/generate-icon-overview.ts
+++ b/packages/foundations/scripts/local/generate-icon-overview.ts
@@ -3,7 +3,6 @@
  */
 
 import { writeFileSync } from 'node:fs';
-import * as prettier from 'prettier';
 import { ALL_ICONS } from '../../src';
 
 const generateIconOverview = async () => {
@@ -49,11 +48,8 @@ data-semantic="informational"
 </div>
 </body>
 </html>`;
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-call
-		const output: string = await prettier.format(iconHtml, {
-			parser: 'html'
-		});
-		writeFileSync('./dev/icons.html', output);
+		// we're formatting the code with Prettier within package.json (to easily resolve to the config)
+		writeFileSync('./dev/icons.html', iconHtml);
 	} catch (error) {
 		console.error(error);
 	}


### PR DESCRIPTION
## Proposed changes

From time to time (or more specifically, when the icons overview gets updated), an unformatted file pops up on localhost, and it even also happens that it gets commited by mistake.

To have it correctly formatted, one even already used prettier, but didn't resolve to the configurations. As we partly store some configuration in the standard file `.editorconfig`, which doesn't seem to get resolved by prettier through it's method [`prettier.resolveConfigFile`](https://prettier.io/docs/api#prettierresolveconfigfilefileurlorpath), but only when used via CLI.

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improvements to existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
