### PR TITLE
chore: disable husky git hooks more clearly

### DIFF
--- a/.github/actions/auto-commit/action.yml
+++ b/.github/actions/auto-commit/action.yml
@@ -39,6 +39,7 @@ runs:
         NEW_PR_BRANCH: ${{ inputs.branch-name }}
         COMMIT_MESSAGE: ${{ inputs.commit-message }}
         COMMIT_FILES: ${{ inputs.commit-files }}
+        HUSKY: 0 # Disable Husky hooks in CI
       run: |
         git config --global user.name "github-actions[bot]"
         git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -47,7 +48,7 @@ runs:
         git add $COMMIT_FILES
 
         # We can't use semantic commits here because of the if statement in the workflow
-        git commit --no-verify --message "$COMMIT_MESSAGE"
+        git commit --message "$COMMIT_MESSAGE"
         git push --force origin "$NEW_PR_BRANCH"
 
     - name: 🪗 Create Pull Request


### PR DESCRIPTION
## Proposed changes

Let's not run a `--no-verify`, but disable HUSKY hooks within CI, as they are meant for localhost improvements.

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improvements to existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
