### PR TITLE
refactor(cicd): node-version single source of truth

### DIFF
--- a/.github/actions/npm-cache/action.yml
+++ b/.github/actions/npm-cache/action.yml
@@ -13,7 +13,6 @@ inputs:
   nodeVersion:
     description: "Node version"
     required: false
-    default: "24"
 runs:
   using: "composite"
   steps:
@@ -23,6 +22,7 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.nodeVersion }}
+        node-version-file: ".nvmrc"
 
     - name: 🖼️ Display node and npm version
       shell: bash


### PR DESCRIPTION
## Proposed changes

Currently we define the node version as a default value in the actions as well as in the `.nvmrc`. This needs to get aligned to only take it from the `.nvmrc` as a default, but leave the option to overwrite it as a parameter to this action.

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improvements to existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
