### PR TITLE
refactor: css condition to scss condition

### DIFF
--- a/packages/components/src/styles/internal/_form-components.scss
+++ b/packages/components/src/styles/internal/_form-components.scss
@@ -372,7 +372,7 @@ $input-valid-types:
 			background-color: colors.$db-adaptive-bg-basic-transparent-semi-hovered;
 		}
 
-		&:is(input, textarea) {
+		@if ($selector == input or $selector == textarea) {
 			/* see https://developer.mozilla.org/en-US/docs/Web/CSS/field-sizing */
 			&[data-field-sizing="content"] {
 				field-sizing: content;
@@ -381,13 +381,13 @@ $input-valid-types:
 			&[data-field-sizing="fixed"] {
 				field-sizing: fixed;
 			}
-		}
 
-		&:is(input, textarea):not(:disabled):read-only {
-			background-color: var(
-				--db-textarea-read-only,
-				#{colors.$db-adaptive-bg-basic-level-1-default}
-			) !important;
+			&:not(:disabled):read-only {
+				background-color: var(
+					--db-#{$selector}-read-only,
+					#{colors.$db-adaptive-bg-basic-level-1-default}
+				) !important;
+			}
 		}
 	}
 


### PR DESCRIPTION
## Proposed changes

Currently we've checked for the elements to be either `input` or `textarea` at the CSS level with `:is()`. Instead as we're using those in a SCSS mixin, we should that for check for those element types in a SCSS condition.

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improvements to existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
