### PR TITLE
refactor: we'd have to run build previous to checking the docs path

### DIFF
--- a/scripts/package.json
+++ b/scripts/package.json
@@ -35,6 +35,7 @@
     "dev:sass": "npm run dev:scss --workspace=@db-ux/core-components",
     "dev:stencil-components": "npm run dev:stencil --workspace=@db-ux/core-components",
     "dev:vue-components": "npm run dev:vue --workspace=@db-ux/core-components",
+    "pretest:docs-file-references": "npm run build",
     "rm-builds:components-build": "rimraf ../packages/components/build",
     "rm-builds:dist": "rimraf --glob showcases/**/dist",
     "rm-builds:foundations-build": "rimraf ../packages/foundations/build",


### PR DESCRIPTION
## Proposed changes

We have to run the build previous to checking the docs path. Elsewhere we couldn't determine whether the files exist that are mentioned in the docs.

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improvements to existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
