### PR TITLE
fix: Keep burger menu visible when drawer has content

### DIFF
--- a/packages/components/src/components/header/header.scss
+++ b/packages/components/src/components/header/header.scss
@@ -53,16 +53,21 @@
 		}
 	}
 
-	// Hide the burger menu if there is no navigation
-	&:has(.db-header-navigation:empty) {
+	// Hide the burger ONLY when the drawer would be empty.
+	// This requires: no main navigation AND no meta navigation AND no secondary action.
+	&:has(.db-header-navigation:empty):has(
+			.db-header-meta-navigation:empty
+		):has(.db-header-secondary-action:empty) {
 		.db-header-burger-menu-container {
 			display: none;
 		}
+	}
 
-		&:has(.db-header-secondary-action:empty) {
-			.db-header-action-container::before {
-				display: none;
-			}
+	// Hide the action-area divider only when both navigation and secondary action are missing.
+	// With no navigation but a secondary action, we keep the divider.
+	&:has(.db-header-navigation:empty):has(.db-header-secondary-action:empty) {
+		.db-header-action-container::before {
+			display: none;
 		}
 	}
 }


### PR DESCRIPTION
* Keep burger visible when drawer has content, hide if nav, meta and secondary are empty

closes https://github.com/db-ux-design-system/core-web/issues/4385


## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improvements to existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->
