### PR TITLE
refactor: adding the PR url to Automated PR description

### DIFF
--- a/.github/actions/auto-commit/action.yml
+++ b/.github/actions/auto-commit/action.yml
@@ -65,7 +65,15 @@ runs:
         NEW_PR_BRANCH: ${{ inputs.branch-name }}
         BASE_BRANCH: ${{ github.head_ref }}
       run: |
-        gh pr create --base "$BASE_BRANCH" --head "$NEW_PR_BRANCH" --title "Automated PR: $COMMIT_MESSAGE" --body "This PR was created automatically by a GitHub Action."
+        PR_BODY="This PR was created automatically by a GitHub Action."
+        # Create the PR and capture its URL
+        PR_URL=$(gh pr create --base "$BASE_BRANCH" --head "$NEW_PR_BRANCH" --title "Automated PR: $COMMIT_MESSAGE" --body "$PR_BODY")
+
+        # Find the PR URL for the base branch
+        BASE_PR_URL=$(gh pr list --base "$BASE_BRANCH" --state open --json url --jq '.[0].url')
+
+        # Update the PR body to include the base branch PR URL
+        gh pr edit "$PR_URL" --body "$PR_BODY\n\nBase branch PR: $BASE_PR_URL"
 
     # https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/making-authenticated-api-requests-with-a-github-app-in-a-github-actions-workflow
     - name: 🧬 Generate a token

--- a/showcases/shared/button.json
+++ b/showcases/shared/button.json
@@ -8,7 +8,7 @@
 				"props": {}
 			},
 			{
-				"name": "(Default) Regular",
+				"name": "(Default) Regular1",
 				"density": "regular",
 				"props": {}
 			},


### PR DESCRIPTION
## Proposed changes

To further document the Automated PRs basis, we'd like to add the URL of the PR that relates to the target branch to the Automated PRs description.

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improvements to existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
