### PR TITLE
fix(select): Angular tests

### DIFF
--- a/.changeset/cyan-scissors-burn.md
+++ b/.changeset/cyan-scissors-burn.md
@@ -1,9 +1,0 @@
----
-"@db-ux/core-components": patch
-"@db-ux/ngx-core-components": patch
-"@db-ux/react-core-components": patch
-"@db-ux/v-core-components": patch
-"@db-ux/wc-core-components": patch
----
-
-fix(select): set placeholder option as selected if it doesn't contain a value

--- a/packages/components/src/components/select/select.lite.tsx
+++ b/packages/components/src/components/select/select.lite.tsx
@@ -238,7 +238,7 @@ export default function DBSelect(props: DBSelectProps) {
 				aria-describedby={props.ariaDescribedBy ?? state._descByIds}>
 				{/* Empty option for floating label */}
 				<Show when={props.variant === 'floating' || props.placeholder}>
-					<option class="placeholder" value="" selected={!props.value}></option>
+					<option class="placeholder" value=""></option>
 				</Show>
 				<Show when={props.options?.length} else={props.children}>
 					<For each={props.options}>

--- a/showcases/angular-showcase/src/app/components/select/select.component.html
+++ b/showcases/angular-showcase/src/app/components/select/select.component.html
@@ -20,7 +20,7 @@
 			[disabled]="exampleProps?.disabled"
 			[icon]="exampleProps?.icon"
 			[required]="exampleProps?.required"
-			[value]="exampleProps?.value"
+			[value]="exampleProps?.value || ''"
 			[message]="exampleProps?.message"
 			[showMessage]="exampleProps?.showMessage"
 			[invalidMessage]="exampleProps?.invalidMessage"


### PR DESCRIPTION
## Proposed changes

The Angular tests are currently failing because of how Angular is handling the first `option` HTML element of a set of `option` HTML elements out of which none is having the `selected` HTML attribute at the very beginning.

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improvements to existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
