### PR TITLE
fix: corrected those CSS path leftovers

### DIFF
--- a/packages/components/src/components/custom-select-dropdown/index.html
+++ b/packages/components/src/components/custom-select-dropdown/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="UTF-8" />
 		<title>DBCustomSelectDropdown</title>
-		<link rel="stylesheet" href="/styles/db-ui-42.css" />
+		<link rel="stylesheet" href="/styles/relative.css" />
 	</head>
 	<body style="padding: var(--db-spacing-fixed-md)">
 		<div class="db-custom-select-dropdown">Test</div>

--- a/packages/components/src/components/custom-select-form-field/index.html
+++ b/packages/components/src/components/custom-select-form-field/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="UTF-8" />
 		<title>DBCustomSelectFormField</title>
-		<link rel="stylesheet" href="/styles/db-ui-42.css" />
+		<link rel="stylesheet" href="/styles/relative.css" />
 	</head>
 	<body style="padding: var(--db-spacing-fixed-md)">
 		<div class="db-custom-select-form-field">Test</div>

--- a/packages/components/src/components/custom-select/index.html
+++ b/packages/components/src/components/custom-select/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="UTF-8" />
 		<title>DBCustomSelect</title>
-		<link rel="stylesheet" href="/styles/db-ui-42.css" />
+		<link rel="stylesheet" href="/styles/relative.css" />
 	</head>
 	<body style="padding: var(--db-spacing-fixed-md)">
 		<div class="db-custom-select">Test</div>


### PR DESCRIPTION
## Proposed changes

Some HTML example files were still including an older version of our general styling file, and those path needed to get updated.

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improvements to existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
