### PR TITLE
fix(button): enhance multi-line text support and update button styles

### DIFF
--- a/packages/components/src/components/button/button.scss
+++ b/packages/components/src/components/button/button.scss
@@ -12,12 +12,15 @@
 	@extend %default-button;
 	@extend %db-overwrite-font-size-md;
 
+	// Multiple lines support
+	max-inline-size: 100%;
+	overflow-wrap: break-word;
+	white-space: break-spaces;
+	text-align: center;
 	color: colors.$db-adaptive-on-bg-basic-emphasis-100-default;
-	block-size: variables.$db-sizing-md;
+	min-block-size: variables.$db-sizing-md;
 	inline-size: fit-content;
 	padding: variables.$db-spacing-fixed-xs variables.$db-spacing-fixed-md;
-
-	// disable text-decoration if someone wants to use the button for an <a> tag
 	text-decoration: none;
 
 	// Square icon only buttons
@@ -25,6 +28,7 @@
 		@include icons.is-icon-text-replace;
 
 		padding: 0;
+		block-size: variables.$db-sizing-md;
 		inline-size: variables.$db-sizing-md;
 
 		&::before {
@@ -36,7 +40,8 @@
 		@extend %db-overwrite-font-size-sm;
 
 		font-weight: 700;
-		block-size: variables.$db-sizing-sm;
+		min-block-size: variables.$db-sizing-sm;
+		padding: variables.$db-spacing-fixed-2xs;
 
 		&:not([data-no-text="true"]) {
 			padding: variables.$db-spacing-fixed-3xs
@@ -49,6 +54,7 @@
 
 		// Square icon only buttons
 		&[data-no-text="true"] {
+			block-size: variables.$db-sizing-sm;
 			inline-size: variables.$db-sizing-sm;
 		}
 	}

--- a/showcases/shared/button.json
+++ b/showcases/shared/button.json
@@ -150,5 +150,32 @@
 				}
 			}
 		]
+	},
+	{
+		"name": "Multi-line Text With Line Breaks",
+		"examples": [
+			{
+				"name": "Multi-line Text With Automatic Line Breaks",
+				"style": { "width": "300px" },
+				"props": {
+					"width": "full"
+				}
+			},
+			{
+				"name": "Multi-line Text With Automatic Line Breaks and Icon",
+				"style": { "width": "300px" },
+				"props": {
+					"width": "full",
+					"icon": "x_placeholder"
+				}
+			},
+			{
+				"name": "Button Small Multi-line Text With Automatic Line Breaks",
+				"style": { "width": "300px" },
+				"props": {
+					"size": "small"
+				}
+			}
+		]
 	}
 ]


### PR DESCRIPTION
## Proposed changes

Fix: Button min-height statt fixed height
Es ist gewünscht, dass Buttons mehrzeilig werden können und in der Höhe mitwachsen, wenn der Text umbricht.
https://github.com/db-ux-design-system/core-team/issues/1064
## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improvements to existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
<img width="1890" height="323" alt="image" src="https://github.com/user-attachments/assets/4733d068-524b-40a6-bc7b-324287ad5a3a" />
