### PR TITLE
docs(checkbox): add formatted infotext examples for Angular, React & Vue

### DIFF
--- a/packages/components/src/components/checkbox/docs/Angular.md
+++ b/packages/components/src/components/checkbox/docs/Angular.md
@@ -48,6 +48,30 @@ export class AppComponent {
 }
 ```
 
+#### Adding Formatted Infotext
+
+The message property of the db-checkbox does not accept HTML content for security reasons (to prevent XSS attacks). To add a richly formatted description, use the `db-infotext` component as a sibling element. You must link both components using the `aria-describedby` attribute to ensure accessibility.
+
+```html
+<db-checkbox aria-describedby="checkbox-message">
+	Example Checkbox
+</db-checkbox>
+<db-infotext id="checkbox-message"> Example <b>Text</b> </db-infotext>
+```
+
+```ts app.component.ts
+import { Component } from "@angular/core";
+import { DBCheckbox, DBInfotext } from "@db-ux/ngx-core-components";
+
+@Component({
+	selector: "app-root",
+	standalone: true,
+	imports: [DBCheckbox, DBInfotext],
+	templateUrl: "./app.component.html"
+})
+export class AppComponent {}
+```
+
 ## How to use with Template Driven Forms
 
 Third party controls require a `ControlValueAccessor` to function with angular forms. Adding an `ngDefaultControl` attribute will allow them to use that directive.

--- a/packages/components/src/components/checkbox/docs/Angular.md
+++ b/packages/components/src/components/checkbox/docs/Angular.md
@@ -50,7 +50,7 @@ export class AppComponent {
 
 #### Adding Formatted Infotext
 
-The message property of the db-checkbox does not accept HTML content for security reasons (to prevent XSS attacks). To add a richly formatted description, use the `db-infotext` component as a sibling element. You must link both components using the `aria-describedby` attribute to ensure accessibility.
+The message property of the db-checkbox does not accept HTML content for security reasons (to prevent XSS attacks). To add a richly formatted description, use the `db-infotext` component as a sibling element. You must link both components using the [`aria-describedby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby)-HTML-attribute to ensure accessibility.
 
 ```html
 <db-checkbox aria-describedby="checkbox-message">

--- a/packages/components/src/components/checkbox/docs/Angular.md
+++ b/packages/components/src/components/checkbox/docs/Angular.md
@@ -56,7 +56,7 @@ The message property of the db-checkbox does not accept HTML content for securit
 <db-checkbox aria-describedby="checkbox-message">
 	Example Checkbox
 </db-checkbox>
-<db-infotext id="checkbox-message"> Example <b>Text</b> </db-infotext>
+<db-infotext id="checkbox-message"> Example <strong>Text</strong> </db-infotext>
 ```
 
 ```ts app.component.ts

--- a/packages/components/src/components/checkbox/docs/HTML.md
+++ b/packages/components/src/components/checkbox/docs/HTML.md
@@ -32,6 +32,6 @@ To add a descriptive text with HTML formatting (e.g., bold or italic text) to a 
 		/>
 		Label
 	</label>
-	<p class="db-infotext" id="checkbox-message">Example <b>Text</b></p>
+	<p class="db-infotext" id="checkbox-message">Example <strong>Text</strong></p>
 </body>
 ```

--- a/packages/components/src/components/checkbox/docs/HTML.md
+++ b/packages/components/src/components/checkbox/docs/HTML.md
@@ -17,7 +17,7 @@ For general installation and configuration take a look at the [components](https
 
 #### Adding Formatted Infotext
 
-To add a descriptive text with HTML formatting (e.g., bold or italic text) to a checkbox, you should use a separate element for the message and link it via the aria-describedby attribute for accessibility. This ensures that screen readers correctly associate the message with the checkbox.
+To add a descriptive text with HTML formatting (e.g., bold or italic text) to a checkbox, you should use a separate element for the message and link it via the [`aria-describedby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby)-HTML-attribute for accessibility. This ensures that screen readers correctly associate the message with the checkbox.
 
 ```html index.html
 <!-- Checkbox with formatted infotext -->

--- a/packages/components/src/components/checkbox/docs/HTML.md
+++ b/packages/components/src/components/checkbox/docs/HTML.md
@@ -14,3 +14,24 @@ For general installation and configuration take a look at the [components](https
 	</label>
 </body>
 ```
+
+#### Adding Formatted Infotext
+
+To add a descriptive text with HTML formatting (e.g., bold or italic text) to a checkbox, you should use a separate element for the message and link it via the aria-describedby attribute for accessibility. This ensures that screen readers correctly associate the message with the checkbox.
+
+```html index.html
+<!-- Checkbox with formatted infotext -->
+...
+<body>
+	<label class="db-checkbox" for="checkbox-element">
+		<input
+			type="checkbox"
+			id="checkbox-element"
+			name="States"
+			aria-describedby="checkbox-message"
+		/>
+		Label
+	</label>
+	<p class="db-infotext" id="checkbox-message">Example <b>Text</b></p>
+</body>
+```

--- a/packages/components/src/components/checkbox/docs/React.md
+++ b/packages/components/src/components/checkbox/docs/React.md
@@ -27,3 +27,33 @@ const App = () => {
 
 export default App;
 ```
+
+#### Adding Formatted Infotext
+
+The message prop of the DBCheckbox does not accept React Nodes or HTML for security reasons (to prevent Cross-Site Scripting (XSS)). To add a richly formatted description, use the DBInfotext component as a sibling element. It is crucial to link both components using the aria-describedby attribute to ensure accessibility.
+
+```tsx App.tsx
+import { DBCheckbox, DBInfotext } from "@db-ux/react-core-components";
+
+const App = () => {
+	return (
+		<div>
+			<DBCheckbox
+				// The aria-describedby attribute links the checkbox to its description.
+				aria-describedby="checkbox-message"
+			>
+				Example Checkbox
+			</DBCheckbox>
+
+			{/* The DBInfotext component holds the formatted message. */}
+			<DBInfotext id="checkbox-message">
+				<span>
+					Example <b>Text</b>
+				</span>
+			</DBInfotext>
+		</div>
+	);
+};
+
+export default App;
+```

--- a/packages/components/src/components/checkbox/docs/React.md
+++ b/packages/components/src/components/checkbox/docs/React.md
@@ -30,7 +30,7 @@ export default App;
 
 #### Adding Formatted Infotext
 
-The message prop of the DBCheckbox does not accept React Nodes or HTML for security reasons (to prevent Cross-Site Scripting (XSS)). To add a richly formatted description, use the DBInfotext component as a sibling element. It is crucial to link both components using the aria-describedby attribute to ensure accessibility.
+The message prop of the DBCheckbox does not accept React Nodes or HTML for security reasons (to prevent Cross-Site Scripting (XSS)). To add a richly formatted description, use the DBInfotext component as a sibling element. It is crucial to link both components using the [`aria-describedby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby)-HTML-attribute to ensure accessibility.
 
 ```tsx App.tsx
 import { DBCheckbox, DBInfotext } from "@db-ux/react-core-components";

--- a/packages/components/src/components/checkbox/docs/React.md
+++ b/packages/components/src/components/checkbox/docs/React.md
@@ -48,7 +48,7 @@ const App = () => {
 			{/* The DBInfotext component holds the formatted message. */}
 			<DBInfotext id="checkbox-message">
 				<span>
-					Example <b>Text</b>
+					Example <strong>Text</strong>
 				</span>
 			</DBInfotext>
 		</div>

--- a/packages/components/src/components/checkbox/docs/React.md
+++ b/packages/components/src/components/checkbox/docs/React.md
@@ -47,9 +47,7 @@ const App = () => {
 
 			{/* The DBInfotext component holds the formatted message. */}
 			<DBInfotext id="checkbox-message">
-				<span>
-					Example <strong>Text</strong>
-				</span>
+			Example <strong>Text</strong>
 			</DBInfotext>
 		</div>
 	);

--- a/packages/components/src/components/checkbox/docs/Vue.md
+++ b/packages/components/src/components/checkbox/docs/Vue.md
@@ -18,3 +18,21 @@ const checkbox = _ref("");
 	</DBCheckbox>
 </template>
 ```
+
+#### Adding Formatted Infotext
+
+The message prop of the DBCheckbox does not accept HTML content for security reasons (to prevent XSS attacks). To add a richly formatted description, use the DBInfotext component as a sibling element. You must link both components using the aria-describedby attribute to ensure accessibility.
+
+```vue App.vue
+<script setup lang="ts">
+import { DBCheckbox, DBInfotext } from "@db-ux/v-core-components";
+</script>
+
+<template>
+	<DBCheckbox aria-describedby="checkbox-message">
+		Example Checkbox
+	</DBCheckbox>
+
+	<DBInfotext id="checkbox-message"> Example <b>Text</b> </DBInfotext>
+</template>
+```

--- a/packages/components/src/components/checkbox/docs/Vue.md
+++ b/packages/components/src/components/checkbox/docs/Vue.md
@@ -21,7 +21,7 @@ const checkbox = _ref("");
 
 #### Adding Formatted Infotext
 
-The message prop of the DBCheckbox does not accept HTML content for security reasons (to prevent XSS attacks). To add a richly formatted description, use the DBInfotext component as a sibling element. You must link both components using the aria-describedby attribute to ensure accessibility.
+The message prop of the DBCheckbox does not accept HTML content for security reasons (to prevent XSS attacks). To add a richly formatted description, use the DBInfotext component as a sibling element. You must link both components using the [`aria-describedby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby)-HTML-attribute to ensure accessibility.
 
 ```vue App.vue
 <script setup lang="ts">

--- a/packages/components/src/components/checkbox/docs/Vue.md
+++ b/packages/components/src/components/checkbox/docs/Vue.md
@@ -33,6 +33,6 @@ import { DBCheckbox, DBInfotext } from "@db-ux/v-core-components";
 		Example Checkbox
 	</DBCheckbox>
 
-	<DBInfotext id="checkbox-message"> Example <b>Text</b> </DBInfotext>
+	<DBInfotext id="checkbox-message"> Example <strong>Text</strong> </DBInfotext>
 </template>
 ```


### PR DESCRIPTION
## Proposed changes

Die Antwort aus dem https://github.com/db-ux-design-system/core-web/issues/4225 soll auch in der Doku der Komponente [How to use](https://design-system.deutschebahn.com/core-web/version/v3.1.4/components/data-input/checkbox/how-to-use) entsprechend dokumentiert sein.

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improvements to existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x ] I have added necessary documentation (if appropriate)
-->


