### PR TITLE
Fix color mode set by color-mode-switch for textarea

### DIFF
--- a/packages/foundations/scss/defaults/default-required.scss
+++ b/packages/foundations/scss/defaults/default-required.scss
@@ -21,6 +21,14 @@
 		@media (prefers-color-scheme: dark) {
 			@include default-color-icons.get-color-icons-dark;
 		}
+
+		[data-mode="dark"] {
+			@include default-color-icons.get-color-icons-dark;
+		}
+
+		[data-mode="light"] {
+			@include default-color-icons.get-color-icons-light;
+		}
 	}
 }
 


### PR DESCRIPTION
## Proposed changes

* Add overrides for data-mode to update tokens when using the color-mode-switcher


The color/icon tokens (--db-textarea-resizer-image) are currently only applied on :root/:host and switched to dark via @media (prefers-color-scheme: dark).
However, the page switcher does not change prefers-color-scheme in this case. It only toggles data-mode="dark/light".
When switching via the UI, the variables from the :root block remain unchanged. But, in DevTools (set Rendering --> prefers-color-scheme) it works because the actual prefers-color-scheme is toggled.

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improvements to existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


Fixes https://github.com/db-ux-design-system/core-web/issues/5031
