### PR TITLE
fix(dependabot): added explicit update types for all dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -109,6 +109,7 @@ updates:
           - "typescript"
           - "tsx"
           - "tslib"
+        # There is no entry for `major`, as these are configured to be ignored in the `ignore` section of this configuration file.
         update-types:
           - "minor"
       # Commitlint

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -109,9 +109,9 @@ updates:
           - "typescript"
           - "tsx"
           - "tslib"
-        # There is no entry for `major`, as these are configured to be ignored in the `ignore` section of this configuration file.
         update-types:
           - "minor"
+          - "major"
       # Commitlint
       commitlint:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -70,50 +70,85 @@ updates:
         patterns:
           - "@playwright*"
           - "playwright*"
+        update-types:
+          - "minor"
+          - "major"
       # Linting and formatting tools
       eslint:
         patterns:
           - "eslint*"
           - "@eslint*"
           - "@typescript-eslint*"
+        update-types:
+          - "minor"
+          - "major"
       stylelint:
         patterns:
           - "stylelint*"
           - "@double-great/stylelint-a11y"
+        update-types:
+          - "minor"
+          - "major"
       prettier:
         patterns:
           - "prettier*"
+        update-types:
+          - "minor"
+          - "major"
       # Build tools and bundlers
       vite:
         patterns:
           - "vite*"
           - "vitest*"
+        update-types:
+          - "minor"
+          - "major"
       # Development tools
       typescript:
         patterns:
           - "typescript"
           - "tsx"
           - "tslib"
+        update-types:
+          - "minor"
       # Commitlint
       commitlint:
         patterns:
           - "@commitlint*"
+        update-types:
+          - "minor"
+          - "major"
       # Other grouped dependencies
       builder.io:
         patterns:
           - "@builder.io/mitosis*"
+        update-types:
+          - "minor"
+          - "major"
       inquirer:
         patterns:
           - "@inquirer/*"
           - "inquirer"
+        update-types:
+          - "minor"
+          - "major"
       mdx-js:
         patterns:
           - "@mdx-js/*"
+        update-types:
+          - "minor"
+          - "major"
       guidepup:
         patterns:
           - "@guidepup/*"
+        update-types:
+          - "minor"
+          - "major"
       next:
         patterns:
           - "@next*"
           - "eslint-config-next"
           - "next"
+        update-types:
+          - "minor"
+          - "major"


### PR DESCRIPTION
## Proposed changes

It seems that currently, no PRs grouped by npmjs organisations would be opened, except the patch ones. According to ChatGPT, we should explicitly define the groups in the Dependabot configuration.

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improvements to existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
