### PR TITLE
fix: cancel-workflow and ensure assets are encrypted for showcases

### DIFF
--- a/.github/workflows/00-cancel-workflow.yml
+++ b/.github/workflows/00-cancel-workflow.yml
@@ -13,6 +13,9 @@ jobs:
     name: Cancel Workflow
     runs-on: ubuntu-24.04 # Use Ubuntu 24.04 explicitly
     steps:
+      - name: ⏬ Checkout repo
+        uses: actions/checkout@v5
+
       - name: 💀 Killing me softly
         run: |
           gh run cancel ${{ github.run_id }}

--- a/.github/workflows/01-build-patternhub.yml
+++ b/.github/workflows/01-build-patternhub.yml
@@ -93,6 +93,8 @@ jobs:
           ASSET_PASSWORD: ${{ secrets.ASSET_PASSWORD }}
           NEXT_PUBLIC_BASE_PATH: ${{ steps.base-path.outputs.result }}
         run: |
+          node node_modules/@db-ux/db-theme-fonts/build/scripts/index.js
+          node node_modules/@db-ux/db-theme-icons/build/scripts/index.js
           npx --no tsx scripts/md-resolve-svg.ts
           npm run build --workspace=patternhub
           echo "path=${NEXT_PUBLIC_BASE_PATH}" >> $GITHUB_OUTPUT

--- a/.github/workflows/01-build-showcases.yml
+++ b/.github/workflows/01-build-showcases.yml
@@ -44,7 +44,10 @@ jobs:
         env:
           ASSET_INIT_VECTOR: ${{ secrets.ASSET_INIT_VECTOR }}
           ASSET_PASSWORD: ${{ secrets.ASSET_PASSWORD }}
-        run: npm run build --workspace=${{ inputs.showcase }}
+        run: |
+          node node_modules/@db-ux/db-theme-fonts/build/scripts/index.js
+          node node_modules/@db-ux/db-theme-icons/build/scripts/index.js
+          npm run build --workspace=${{ inputs.showcase }}
 
       - name: ⏫ Upload ${{ inputs.showcase }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -31,12 +31,6 @@ jobs:
     uses: ./.github/workflows/00-init.yml
     secrets: inherit
 
-  cancel-init:
-    if: ${{ needs.init.result == 'failure' }}
-    uses: ./.github/workflows/00-cancel-workflow.yml
-    secrets: inherit
-    needs: [init]
-
   scan-secrets:
     if: github.event.pull_request == null || github.event.pull_request.head.repo.owner.login == 'db-ux-design-system'
     uses: ./.github/workflows/00-scan-secrets.yml
@@ -45,18 +39,12 @@ jobs:
     uses: ./.github/workflows/01-get-playwright-version.yml
     needs: [init]
 
-  cancel-on-failure-get-playwright-version:
-    if: ${{ needs.get-playwright-version.result == 'failure' }}
-    uses: ./.github/workflows/00-cancel-workflow.yml
-    secrets: inherit
-    needs: [get-playwright-version]
-
   lint:
     uses: ./.github/workflows/01-lint.yml
     needs: [init]
 
   cancel-on-failure-lint:
-    if: ${{ needs.lint.result == 'failure' }}
+    if: ${{ !cancelled() && needs.lint.result == 'failure' }}
     uses: ./.github/workflows/00-cancel-workflow.yml
     secrets: inherit
     needs: [lint]
@@ -66,7 +54,7 @@ jobs:
     needs: [init]
 
   cancel-on-failure-test:
-    if: ${{ needs.test.result == 'failure' }}
+    if: ${{ !cancelled() && needs.test.result == 'failure' }}
     uses: ./.github/workflows/00-cancel-workflow.yml
     secrets: inherit
     needs: [test]
@@ -76,7 +64,7 @@ jobs:
     needs: [init]
 
   cancel-on-failure-build-packages:
-    if: ${{ needs.build-packages.result == 'failure' }}
+    if: ${{ !cancelled() && needs.build-packages.result == 'failure' }}
     uses: ./.github/workflows/00-cancel-workflow.yml
     secrets: inherit
     needs: [build-packages]
@@ -88,7 +76,7 @@ jobs:
       version: ${{ needs.get-playwright-version.outputs.version }}
 
   cancel-on-failure-init-playwright:
-    if: ${{ needs.init-playwright.result == 'failure' }}
+    if: ${{ !cancelled() && needs.init-playwright.result == 'failure' }}
     uses: ./.github/workflows/00-cancel-workflow.yml
     secrets: inherit
     needs: [init-playwright]
@@ -98,7 +86,7 @@ jobs:
     needs: [build-packages]
 
   cancel-on-failure-build-outputs:
-    if: ${{ needs.build-outputs.result == 'failure' }}
+    if: ${{ !cancelled() && needs.build-outputs.result == 'failure' }}
     uses: ./.github/workflows/00-cancel-workflow.yml
     secrets: inherit
     needs: [build-outputs]
@@ -109,23 +97,11 @@ jobs:
     with:
       version: ${{ needs.get-playwright-version.outputs.version }}
 
-  cancel-on-failure-test-components:
-    if: ${{ needs.test-components.result == 'failure' }}
-    uses: ./.github/workflows/00-cancel-workflow.yml
-    secrets: inherit
-    needs: [test-components]
-
   test-foundations:
     uses: ./.github/workflows/02-e2e-foundations.yml
     needs: [build-packages, get-playwright-version]
     with:
       version: ${{ needs.get-playwright-version.outputs.version }}
-
-  cancel-on-failure-test-foundations:
-    if: ${{ needs.test-foundations.result == 'failure' }}
-    uses: ./.github/workflows/00-cancel-workflow.yml
-    secrets: inherit
-    needs: [test-foundations]
 
   build-showcase-stencil:
     uses: ./.github/workflows/01-build-showcases.yml
@@ -134,7 +110,7 @@ jobs:
       showcase: stencil-showcase
 
   cancel-on-failure-build-showcase-stencil:
-    if: ${{ needs.build-showcase-stencil.result == 'failure' }}
+    if: ${{ !cancelled() && needs.build-showcase-stencil.result == 'failure' }}
     uses: ./.github/workflows/00-cancel-workflow.yml
     secrets: inherit
     needs: [build-showcase-stencil]
@@ -146,7 +122,7 @@ jobs:
       showcase: angular-showcase
 
   cancel-on-failure-build-showcase-angular:
-    if: ${{ needs.build-showcase-angular.result == 'failure' }}
+    if: ${{ !cancelled() && needs.build-showcase-angular.result == 'failure' }}
     uses: ./.github/workflows/00-cancel-workflow.yml
     secrets: inherit
     needs: [build-showcase-angular]
@@ -158,7 +134,7 @@ jobs:
       showcase: angular-ssr-showcase
 
   cancel-on-failure-build-showcase-angular-ssr:
-    if: ${{ needs.build-showcase-angular-ssr.result == 'failure' }}
+    if: ${{ !cancelled() && needs.build-showcase-angular-ssr.result == 'failure' }}
     uses: ./.github/workflows/00-cancel-workflow.yml
     secrets: inherit
     needs: [build-showcase-angular-ssr]
@@ -170,7 +146,7 @@ jobs:
       showcase: react-showcase
 
   cancel-on-failure-build-showcase-react:
-    if: ${{ needs.build-showcase-react.result == 'failure' }}
+    if: ${{ !cancelled() && needs.build-showcase-react.result == 'failure' }}
     uses: ./.github/workflows/00-cancel-workflow.yml
     secrets: inherit
     needs: [build-showcase-react]
@@ -182,7 +158,7 @@ jobs:
       showcase: next-showcase
 
   cancel-on-failure-build-showcase-next:
-    if: ${{ needs.build-showcase-next.result == 'failure' }}
+    if: ${{ !cancelled() && needs.build-showcase-next.result == 'failure' }}
     uses: ./.github/workflows/00-cancel-workflow.yml
     secrets: inherit
     needs: [build-showcase-next]
@@ -194,7 +170,7 @@ jobs:
       showcase: vue-showcase
 
   cancel-on-failure-build-showcase-vue:
-    if: ${{ needs.build-showcase-vue.result == 'failure' }}
+    if: ${{ !cancelled() && needs.build-showcase-vue.result == 'failure' }}
     uses: ./.github/workflows/00-cancel-workflow.yml
     secrets: inherit
     needs: [build-showcase-vue]
@@ -206,7 +182,7 @@ jobs:
       showcase: nuxt-showcase
 
   cancel-on-failure-build-showcase-nuxt:
-    if: ${{ needs.build-showcase-nuxt.result == 'failure' }}
+    if: ${{ !cancelled() && needs.build-showcase-nuxt.result == 'failure' }}
     uses: ./.github/workflows/00-cancel-workflow.yml
     secrets: inherit
     needs: [build-showcase-nuxt]
@@ -216,7 +192,7 @@ jobs:
     needs: [build-packages]
 
   cancel-on-failure-build-showcase-patternhub:
-    if: ${{ needs.build-showcase-patternhub.result == 'failure' }}
+    if: ${{ !cancelled() && needs.build-showcase-patternhub.result == 'failure' }}
     uses: ./.github/workflows/00-cancel-workflow.yml
     secrets: inherit
     needs: [build-showcase-patternhub]
@@ -228,24 +204,12 @@ jobs:
       version: ${{ needs.get-playwright-version.outputs.version }}
       showcase: stencil-showcase
 
-  cancel-on-failure-test-showcase-stencil:
-    if: ${{ needs.test-showcase-stencil.result == 'failure' }}
-    uses: ./.github/workflows/00-cancel-workflow.yml
-    secrets: inherit
-    needs: [test-showcase-stencil]
-
   test-showcase-angular:
     uses: ./.github/workflows/02-e2e-showcases.yml
     needs: [build-showcase-angular, get-playwright-version]
     with:
       version: ${{ needs.get-playwright-version.outputs.version }}
       showcase: angular-showcase
-
-  cancel-on-failure-test-showcase-angular:
-    if: ${{ needs.test-showcase-angular.result == 'failure' }}
-    uses: ./.github/workflows/00-cancel-workflow.yml
-    secrets: inherit
-    needs: [test-showcase-angular]
 
   test-showcase-react:
     uses: ./.github/workflows/02-e2e-showcases.yml
@@ -254,12 +218,6 @@ jobs:
       version: ${{ needs.get-playwright-version.outputs.version }}
       showcase: react-showcase
 
-  cancel-on-failure-test-showcase-react:
-    if: ${{ needs.test-showcase-react.result == 'failure' }}
-    uses: ./.github/workflows/00-cancel-workflow.yml
-    secrets: inherit
-    needs: [test-showcase-react]
-
   test-showcase-vue:
     uses: ./.github/workflows/02-e2e-showcases.yml
     needs: [build-showcase-vue, get-playwright-version]
@@ -267,24 +225,12 @@ jobs:
       version: ${{ needs.get-playwright-version.outputs.version }}
       showcase: vue-showcase
 
-  cancel-on-failure-test-showcase-vue:
-    if: ${{ needs.test-showcase-vue.result == 'failure' }}
-    uses: ./.github/workflows/00-cancel-workflow.yml
-    secrets: inherit
-    needs: [test-showcase-vue]
-
   test-showcase-patternhub:
     uses: ./.github/workflows/02-e2e-patternhub.yml
     needs: [build-showcase-patternhub, get-playwright-version]
     with:
       version: ${{ needs.get-playwright-version.outputs.version }}
       path: ${{ needs.build-showcase-patternhub.outputs.path }}
-
-  cancel-on-failure-test-showcase-patternhub:
-    if: ${{ needs.test-showcase-patternhub.result == 'failure' }}
-    uses: ./.github/workflows/00-cancel-workflow.yml
-    secrets: inherit
-    needs: [test-showcase-patternhub]
 
   regenerate-snapshots-components:
     if: ${{ !cancelled() && needs.test-components.result == 'failure' }}


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

- cancel-workflow failed because of a missing checkout
- sometimes the `npm` cache don't have the DB assets decrypted, we ensure to decrypt them before building the showcases

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improvements to existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
