### PR TITLE
refactor(CustomSelect): `disable` simplification

### DIFF
--- a/packages/components/src/components/custom-select/custom-select.lite.tsx
+++ b/packages/components/src/components/custom-select/custom-select.lite.tsx
@@ -922,7 +922,8 @@ export default function DBCustomSelect(props: DBCustomSelectProps) {
 			data-selected-type={props.multiple ? props.selectedType : 'text'}
 			data-hide-label={getHideProp(props.showLabel)}
 			data-icon={props.icon}
-			data-show-icon={getBooleanAsString(props.showIcon)}>
+			data-show-icon={getBooleanAsString(props.showIcon)}
+			inert={tabIndex={props.disabled ? "true" : undefined}}>
 			<label id={state._labelId}>
 				{props.label ?? DEFAULT_LABEL}
 				<select
@@ -970,8 +971,6 @@ export default function DBCustomSelect(props: DBCustomSelectProps) {
 					<summary
 						id={state._summaryId}
 						class="db-custom-select-form-field"
-						aria-disabled={getBooleanAsString(props.disabled)}
-						tabIndex={props.disabled ? -1 : undefined}
 						aria-labelledby={state._labelId}>
 						<Show when={state._selectedLabels?.length}>
 							<span
@@ -1185,7 +1184,6 @@ export default function DBCustomSelect(props: DBCustomSelectProps) {
 					size="small"
 					name={state._id}
 					form={state._id}
-					disabled={getBoolean(props.disabled, 'disabled')}
 					onClick={(event) => state.handleClearAll(event)}>
 					{props.clearSelectionText}
 					<DBTooltip placement="top">


### PR DESCRIPTION
## Proposed changes

Instead of deactivating every single interactive element in that CustomSelect, we should set the [`inert`](https://web.dev/articles/inert) attribute, and could remove unnecessary `aria-disabled` and `tabIndex` props.

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improvements to existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
