### PR TITLE
docs(HTML): added Invoker Commands

### DIFF
--- a/.changeset/four-buckets-sneeze.md
+++ b/.changeset/four-buckets-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@db-ux/core-components": patch
+---
+
+docs(HTML): added Invoker Commands to header and drawer "how to use" documentation

--- a/packages/components/src/components/drawer/docs/HTML.md
+++ b/packages/components/src/components/drawer/docs/HTML.md
@@ -10,7 +10,7 @@ If you use `width !== full` you are able to overwrite the `max-width` with `--db
 
 Use [Invoker Commands](https://developer.mozilla.org/en-US/docs/Web/API/Invoker_Commands_API) (`command` and `commandfor` HTML attributes) to declaratively connect buttons with the `<dialog>` element. Supported built-in commands for `<dialog>` are `show-modal` and `close`.
 
-If you do need to provide support for [browser versions that haven't implemented Invoker Commands](https://caniuse.com/wf-invoker-commands), add a feature detection fallback in JavaScript (see example below) or the [polyfill `invokers-polyfill`](https://github.com/keithamus/invokers-polyfill)).
+If you do need to provide support for [browser versions that haven't implemented Invoker Commands](https://caniuse.com/wf-invoker-commands), add a feature detection fallback in JavaScript (see example below) or the [polyfill `invokers-polyfill`](https://github.com/keithamus/invokers-polyfill).
 
 ```html index.html
 <!-- index.html -->

--- a/packages/components/src/components/drawer/docs/HTML.md
+++ b/packages/components/src/components/drawer/docs/HTML.md
@@ -8,17 +8,26 @@ If you use `width !== full` you are able to overwrite the `max-width` with `--db
 
 ### Use component
 
+Use [Invoker Commands](https://developer.mozilla.org/en-US/docs/Web/API/Invoker_Commands_API) (`command` and `commandfor` HTML attributes) to declaratively connect buttons with the `<dialog>` element. Supported built-in commands for `<dialog>` are `show-modal` and `close`.
+
+If you do need to provide support for [browser versions that haven't implemented Invoker Commands](https://caniuse.com/wf-invoker-commands), add a feature detection fallback in JavaScript (see example below) or the [polyfill `invokers-polyfill`](https://github.com/keithamus/invokers-polyfill)).
+
 ```html index.html
 <!-- index.html -->
 ...
 <body>
-	<dialog class="db-drawer" data-backdrop="true" open>
+	<button class="db-button" command="show-modal" commandfor="my-drawer">
+		Open Drawer
+	</button>
+	<dialog id="my-drawer" class="db-drawer" data-backdrop="true">
 		<article class="db-drawer-container">
 			<header class="db-drawer-header">
 				<button
 					class="db-button button-close-drawer is-icon-text-replace"
 					data-icon="cross"
 					data-variant="ghost"
+					command="close"
+					commandfor="my-drawer"
 				>
 					Close Button
 				</button>
@@ -26,5 +35,29 @@ If you use `width !== full` you are able to overwrite the `max-width` with `--db
 			<div class="db-drawer-content">My Drawer content</div>
 		</article>
 	</dialog>
+
+	<script>
+		/*
+		 * Feature detection for Invoker Commands:
+		 * If the browser does not support the `command` and `commandfor`
+		 * HTML attributes, we fall back to JavaScript event handlers.
+		 */
+		if (!("CommandEvent" in window)) {
+			const openButton = document.querySelector(
+				'[commandfor="my-drawer"][command="show-modal"]'
+			);
+			const closeButton = document.querySelector(
+				'[commandfor="my-drawer"][command="close"]'
+			);
+			const drawer = document.getElementById("my-drawer");
+
+			openButton?.addEventListener("click", () => {
+				drawer?.showModal();
+			});
+			closeButton?.addEventListener("click", () => {
+				drawer?.close();
+			});
+		}
+	</script>
 </body>
 ```

--- a/packages/components/src/components/drawer/docs/HTML.md
+++ b/packages/components/src/components/drawer/docs/HTML.md
@@ -42,7 +42,10 @@ If you do need to provide support for [browser versions that haven't implemented
 		 * If the browser does not support the `command` and `commandfor`
 		 * HTML attributes, we fall back to JavaScript event handlers.
 		 */
-		if (!("CommandEvent" in window)) {
+		if (
+			!("command" in HTMLButtonElement.prototype) ||
+			!("commandFor" in HTMLButtonElement.prototype)
+		) {
 			const openButton = document.querySelector(
 				'[commandfor="my-drawer"][command="show-modal"]'
 			);
@@ -52,10 +55,10 @@ If you do need to provide support for [browser versions that haven't implemented
 			const drawer = document.getElementById("my-drawer");
 
 			openButton?.addEventListener("click", () => {
-				drawer?.showModal();
+				drawer?.showModal?.();
 			});
 			closeButton?.addEventListener("click", () => {
-				drawer?.close();
+				drawer?.close?.();
 			});
 		}
 	</script>

--- a/packages/components/src/components/header/docs/HTML.md
+++ b/packages/components/src/components/header/docs/HTML.md
@@ -6,7 +6,7 @@ For general installation and configuration take a look at the [components](https
 
 Use [Invoker Commands](https://developer.mozilla.org/en-US/docs/Web/API/Invoker_Commands_API) (`command` and `commandfor` HTML attributes) to declaratively connect the burger menu button with the drawer `<dialog>` element, and the close button inside the drawer. Supported built-in commands for `<dialog>` are `show-modal` and `close`.
 
-If you do need to provide support for [browser versions that haven't implemented Invoker Commands](https://caniuse.com/wf-invoker-commands), add a feature detection fallback in JavaScript (see example below) or the [polyfill `invokers-polyfill`](https://github.com/keithamus/invokers-polyfill)).
+If you do need to provide support for [browser versions that haven't implemented Invoker Commands](https://caniuse.com/wf-invoker-commands), add a feature detection fallback in JavaScript (see example below) or the [polyfill `invokers-polyfill`](https://github.com/keithamus/invokers-polyfill).
 
 ```html index.html
 <!-- index.html -->

--- a/packages/components/src/components/header/docs/HTML.md
+++ b/packages/components/src/components/header/docs/HTML.md
@@ -4,12 +4,16 @@ For general installation and configuration take a look at the [components](https
 
 ### Use component
 
+Use [Invoker Commands](https://developer.mozilla.org/en-US/docs/Web/API/Invoker_Commands_API) (`command` and `commandfor` HTML attributes) to declaratively connect the burger menu button with the drawer `<dialog>` element, and the close button inside the drawer. Supported built-in commands for `<dialog>` are `show-modal` and `close`.
+
+If you do need to provide support for [browser versions that haven't implemented Invoker Commands](https://caniuse.com/wf-invoker-commands), add a feature detection fallback in JavaScript (see example below) or the [polyfill `invokers-polyfill`](https://github.com/keithamus/invokers-polyfill)).
+
 ```html index.html
 <!-- index.html -->
 ...
 <body>
 	<header class="db-header">
-		<dialog class="db-drawer">
+		<dialog id="header-drawer" class="db-drawer">
 			<article
 				class="db-drawer-container db-header-drawer"
 				data-spacing="small"
@@ -21,6 +25,8 @@ For general installation and configuration take a look at the [components](https
 						class="db-button button-close-drawer is-icon-text-replace"
 						data-icon="cross"
 						data-variant="text"
+						command="close"
+						commandfor="header-drawer"
 					>
 						Close Button
 					</button>
@@ -139,6 +145,8 @@ For general installation and configuration take a look at the [components](https
 						class="db-button is-icon-text-replace"
 						data-icon="menu"
 						data-variant="text"
+						command="show-modal"
+						commandfor="header-drawer"
 					>
 						BurgerMenu
 					</button>
@@ -167,5 +175,29 @@ For general installation and configuration take a look at the [components](https
 			</div>
 		</div>
 	</header>
+
+	<script>
+		/*
+		 * Feature detection for Invoker Commands:
+		 * If the browser does not support the `command` and `commandfor`
+		 * HTML attributes, we fall back to JavaScript event handlers.
+		 */
+		if (!("CommandEvent" in window)) {
+			const burgerMenuButton = document.querySelector(
+				'[commandfor="header-drawer"][command="show-modal"]'
+			);
+			const closeButton = document.querySelector(
+				'[commandfor="header-drawer"][command="close"]'
+			);
+			const drawer = document.getElementById("header-drawer");
+
+			burgerMenuButton?.addEventListener("click", () => {
+				drawer?.showModal();
+			});
+			closeButton?.addEventListener("click", () => {
+				drawer?.close();
+			});
+		}
+	</script>
 </body>
 ```

--- a/packages/components/src/components/header/docs/HTML.md
+++ b/packages/components/src/components/header/docs/HTML.md
@@ -182,7 +182,10 @@ If you do need to provide support for [browser versions that haven't implemented
 		 * If the browser does not support the `command` and `commandfor`
 		 * HTML attributes, we fall back to JavaScript event handlers.
 		 */
-		if (!("CommandEvent" in window)) {
+		if (
+			!("command" in HTMLButtonElement.prototype) ||
+			!("commandFor" in HTMLButtonElement.prototype)
+		) {
 			const burgerMenuButton = document.querySelector(
 				'[commandfor="header-drawer"][command="show-modal"]'
 			);
@@ -192,10 +195,10 @@ If you do need to provide support for [browser versions that haven't implemented
 			const drawer = document.getElementById("header-drawer");
 
 			burgerMenuButton?.addEventListener("click", () => {
-				drawer?.showModal();
+				drawer?.showModal?.();
 			});
 			closeButton?.addEventListener("click", () => {
-				drawer?.close();
+				drawer?.close?.();
 			});
 		}
 	</script>


### PR DESCRIPTION
## Proposed changes

For gluing the trigger (button) and opened element (dialog) together without JS, we'd like to suggest the developers to use the established, baseline Invoker Commands feature.

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improvements to existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/docs-html-added-baseline-web-feature>

<!-- DBUX-TEST-URL-END -->