### PR TITLE
fix: re-added lint-test workflow with codespell step

### DIFF
--- a/.github/workflows/01-lint-test.yml
+++ b/.github/workflows/01-lint-test.yml
@@ -13,13 +13,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        command: ["lint", "test"]
+        command: ["lint", "test", "codespell"]
     steps:
       - name: ⏬️ Checkout repo
         uses: actions/checkout@v6
 
       - name: 🔄 Init Cache
         uses: ./.github/actions/npm-cache
+
+      - name: 📖 Check spelling
+        if: ${{ matrix.command == 'codespell' }}
+        run: |
+          npm run lint:codespell
 
       - name: ⚡ Run Lint
         if: ${{ matrix.command == 'lint' }}


### PR DESCRIPTION
## Proposed changes

~Re-Added codespell command to lint-test workflow. These have been removed with commit b84bc340da1a22f411ae9b97aa1398ba9e68aa99 and the commit message "chore: remove codespell linting step and update configuration path" so that the reason for that removal are totally unclear.~
The reason was, that it has been run twice.

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improvements to existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/refactor-re-added-lint-test-workflow-with-codespell-step>

<!-- DBUX-TEST-URL-END -->