### PR TITLE
fix: add `--ignore-workspace` flag to `pnpm pack` command in `publish` script

### DIFF
--- a/scripts/github/publish-npm.js
+++ b/scripts/github/publish-npm.js
@@ -100,7 +100,10 @@ for (const { dir, name: PACKAGE } of packages) {
 	}
 
 	console.log('📦 Create npm package');
-	execSync(`pnpm pack --quiet --config.ignore-scripts=true`, { cwd: dir });
+	execSync(
+		`pnpm pack --quiet --config.ignore-scripts=true --ignore-workspace`,
+		{ cwd: dir }
+	);
 }
 
 let TAG = 'latest';


### PR DESCRIPTION
## Proposed changes

Our [publish process was failing](https://github.com/db-ux-design-system/core-web/actions/runs/25664427099/job/75338949137).

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improvements to existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/fix-publish>

<!-- DBUX-TEST-URL-END -->