### PR TITLE
refactor(prettier): ignore lock-file

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,6 @@
 assets/fonts/**/sources/
 public/
-package-lock.json
+pnpm-lock.yaml
 build/
 node_modules
 output


### PR DESCRIPTION
## Proposed changes

We have been ignoring the lock file for npm previously, and should continue doing so for pnpm. As this is a generated file, doing prettier isn't necessary, and local changes vs. changes in the CI might lead to different code styles, which would result in unnecessary code changes that only relate to code style in this file.

Part of https://github.com/db-ux-design-system/core-web/issues/6656

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improvements to existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/fix-prettier-ignore-lock-file>

<!-- DBUX-TEST-URL-END -->