### PR TITLE
fix: flacky screen-reader tests by native retries

### DIFF
--- a/.github/workflows/02-e2e-screen-reader.yml
+++ b/.github/workflows/02-e2e-screen-reader.yml
@@ -15,9 +15,11 @@ jobs:
   playwright-screen-reader:
     name: 🧪🎭 - screen-reader - ${{ matrix.os }} - react - ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
     runs-on: ${{ matrix.os }}
+    concurrency:
+      group: screen-reader-${{ matrix.os }}-${{ matrix.shardIndex }}
+      cancel-in-progress: false
     strategy:
       fail-fast: false
-      max-parallel: 1 # Run one attempt at a time
       matrix:
         # TODO: enable again after guidepup controlling Voiceover on MacOS 14 and 15 gets more stable
         # https://github.com/actions/runner-images/issues/11257 needs to get fixed for that
@@ -26,7 +28,6 @@ jobs:
         os: [windows-2022] # macOS is not perfectly supported yet, we disable it for now
         shardIndex: [1, 2, 3, 4]
         shardTotal: [4]
-        attempt: [1, 2, 3] # 3 total attempts
     steps:
       - name: ⏬ Checkout repo
         uses: actions/checkout@v6
@@ -59,7 +60,7 @@ jobs:
         env:
           showcase: react-showcase
         run: |
-          pnpm --filter react-showcase run test-sr:${{ env.OS }} --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+          pnpm --filter react-showcase run test-sr:${{ env.OS }} --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --retries=2
 
       - name: 🆙 Upload test results
         if: failure()

--- a/.github/workflows/02-e2e-screen-reader.yml
+++ b/.github/workflows/02-e2e-screen-reader.yml
@@ -60,7 +60,7 @@ jobs:
         env:
           showcase: react-showcase
         run: |
-          pnpm --filter react-showcase run test-sr:${{ env.OS }} --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --retries=2
+          pnpm --filter react-showcase run test-sr:${{ env.OS }} --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --retries=5
 
       - name: 🆙 Upload test results
         if: failure()

--- a/.github/workflows/02-e2e-screen-reader.yml
+++ b/.github/workflows/02-e2e-screen-reader.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      max-parallel: 1 # Run one attempt at a time
       matrix:
         # TODO: enable again after guidepup controlling Voiceover on MacOS 14 and 15 gets more stable
         # https://github.com/actions/runner-images/issues/11257 needs to get fixed for that
@@ -25,6 +26,7 @@ jobs:
         os: [windows-2022] # macOS is not perfectly supported yet, we disable it for now
         shardIndex: [1, 2, 3, 4]
         shardTotal: [4]
+        attempt: [1, 2, 3] # 3 total attempts
     steps:
       - name: ⏬ Checkout repo
         uses: actions/checkout@v6

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -347,7 +347,8 @@ jobs:
     if: |
       github.event_name == 'release' ||
       needs.init.outputs.test-ally == 'true' ||
-      github.event.pull_request == null
+      github.event.pull_request == null ||
+      github.event.pull_request.number == 6724
     uses: ./.github/workflows/02-e2e-screen-reader.yml
     needs: [test-showcase-react, init-playwright, init]
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-configure-file { "MD013": false, "MD041":false } -->
+test <!-- markdownlint-configure-file { "MD013": false, "MD041":false } -->
 <!-- markdownlint-disable MD033 MD010 -->
 
 <picture><source srcset="https://design-system.deutschebahn.com/images/db-ux-design-system-v3-header.avif" type="image/avif"><source srcset="https://design-system.deutschebahn.com/images/db-ux-design-system-v3-header.webp" type="image/webp"><img src="https://design-system.deutschebahn.com/images/db-ux-design-system-v3-header.jpg" alt=""></picture>


### PR DESCRIPTION
## Proposed changes

Currently, we are experiencing unreliable screen-reader tests, with at least one of those steps failing on the first attempt. After rerunning the test (up to two more times in extreme situations), the problem disappears and the expected result is reported. The downside of this approach is that mismatches might be expected due to changes, but unexpected failures of regular jobs outnumber them by far.

~If this native approach succeeds, it makes the other approach by an action obsolete and closes https://github.com/db-ux-design-system/core-web/pull/6725~

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improvements to existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/fix-flacky-screen-reader-tests-by-native-retries>

<!-- DBUX-TEST-URL-END -->