### PR TITLE
fix: correct relative asset paths for whitelabel theme

### DIFF
--- a/.changeset/calm-bikes-decide.md
+++ b/.changeset/calm-bikes-decide.md
@@ -2,4 +2,4 @@
 "@db-ux/core-foundations": patch
 ---
 
-fix: wrong path for whitelabel theme relative.css
+fix: correct default relative asset base for fonts/icons in `build/styles/theme/relative.css` and other `*relative.css` files

--- a/.changeset/calm-bikes-decide.md
+++ b/.changeset/calm-bikes-decide.md
@@ -1,0 +1,5 @@
+---
+"@db-ux/core-foundations": patch
+---
+
+fix: wrong path for whitelabel theme relative.css

--- a/packages/foundations/README.md
+++ b/packages/foundations/README.md
@@ -60,7 +60,7 @@ The `bundle.css` applies those default:
 
 ### CSS
 
-Default assets path for `relative.css` is `../assets`. Make sure to copy all used resources like icons and fonts into your `public` folder before build. **Or** you use a modern bundler which handles bundling for you. In this case use `[rollup|webpack].css`.
+Default assets path for `relative.css` is `../../assets`. Make sure to copy all used resources like icons and fonts into your `public` folder before build. **Or** you use a modern bundler which handles bundling for you. In this case use `[rollup|webpack].css`.
 
 #### Import
 

--- a/packages/foundations/scss/theme/_default.assets-paths.scss
+++ b/packages/foundations/scss/theme/_default.assets-paths.scss
@@ -1,2 +1,2 @@
-$icons-path: "../assets/icons/" !default;
-$fonts-path: "../assets/fonts/" !default;
+$icons-path: "../../assets/icons/" !default;
+$fonts-path: "../../assets/fonts/" !default;


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

After extracting the whitelabel theme, we didn't correct the relative paths for assets.

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improvements to existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/fix-whitelabel-relative-asset-paths>

<!-- DBUX-TEST-URL-END -->