### PR TITLE
refactor(components): use `import type` for type-only imports in all component models

### DIFF
--- a/packages/components/_templates/mitosis/new/component/model.ejs.t
+++ b/packages/components/_templates/mitosis/new/component/model.ejs.t
@@ -1,7 +1,7 @@
 ---
 to: src/components/<%= name %>/model.ts
 ---
-import {
+import type {
 <% if(formValue!=="no"){   -%>
 	ChangeEventProps,
 	ChangeEventState,

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -37,7 +37,7 @@
     "dev:angular": "nodemon --watch src --watch scripts --watch configs --ext tsx,ts,cjs --exec \"npm run compile:angular\"",
     "dev:html": "pnpm run copy-assets && pnpm run build-assets && pnpm run build-style:01_sass && vite --open",
     "dev:react": "nodemon --watch src --watch scripts --watch configs --ext tsx,ts,cjs --exec \"pnpm run compile:react\"",
-    "dev:scss": "sass src:build --load-path=node_modules --watch",
+    "dev:scss": "sass src:build --load-path=node_modules --watch --source-map",
     "dev:stencil": "nodemon --watch src --watch scripts --watch configs --ext tsx,ts,cjs --exec \"pnpm run compile:stencil\"",
     "dev:vue": "nodemon --watch src --watch scripts --watch configs --ext tsx,ts,cjs --exec \"pnpm run compile:vue\"",
     "generate:agent": "mitosis build --config=configs/mitosis.agent.config.cjs",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -37,7 +37,7 @@
     "dev:angular": "nodemon --watch src --watch scripts --watch configs --ext tsx,ts,cjs --exec \"npm run compile:angular\"",
     "dev:html": "pnpm run copy-assets && pnpm run build-assets && pnpm run build-style:01_sass && vite --open",
     "dev:react": "nodemon --watch src --watch scripts --watch configs --ext tsx,ts,cjs --exec \"pnpm run compile:react\"",
-    "dev:scss": "pnpm run build-style:01_sass -- --watch --source-map",
+    "dev:scss": "sass src:build --load-path=node_modules --watch",
     "dev:stencil": "nodemon --watch src --watch scripts --watch configs --ext tsx,ts,cjs --exec \"pnpm run compile:stencil\"",
     "dev:vue": "nodemon --watch src --watch scripts --watch configs --ext tsx,ts,cjs --exec \"pnpm run compile:vue\"",
     "generate:agent": "mitosis build --config=configs/mitosis.agent.config.cjs",

--- a/packages/components/src/components/accordion-item/model.ts
+++ b/packages/components/src/components/accordion-item/model.ts
@@ -1,4 +1,4 @@
-import {
+import type {
 	GlobalProps,
 	InitializedState,
 	NameProps,

--- a/packages/components/src/components/accordion/model.ts
+++ b/packages/components/src/components/accordion/model.ts
@@ -1,5 +1,5 @@
-import { GlobalProps, InitializedState } from '../../shared/model';
-import { DBAccordionItemDefaultProps } from '../accordion-item/model';
+import type { GlobalProps, InitializedState } from '../../shared/model';
+import type { DBAccordionItemDefaultProps } from '../accordion-item/model';
 
 export const AccordionVariantList = ['divider', 'card'] as const;
 export type AccordionVariantType = (typeof AccordionVariantList)[number];

--- a/packages/components/src/components/badge/model.ts
+++ b/packages/components/src/components/badge/model.ts
@@ -1,4 +1,4 @@
-import {
+import type {
 	EmphasisProps,
 	GlobalProps,
 	GlobalState,

--- a/packages/components/src/components/brand/model.ts
+++ b/packages/components/src/components/brand/model.ts
@@ -1,4 +1,4 @@
-import {
+import type {
 	GlobalProps,
 	GlobalState,
 	IconProps,

--- a/packages/components/src/components/button/model.ts
+++ b/packages/components/src/components/button/model.ts
@@ -1,4 +1,4 @@
-import {
+import type {
 	ClickEventProps,
 	GlobalProps,
 	GlobalState,

--- a/packages/components/src/components/card/model.ts
+++ b/packages/components/src/components/card/model.ts
@@ -1,4 +1,4 @@
-import {
+import type {
 	ClickEventProps,
 	ClickEventState,
 	GlobalProps,

--- a/packages/components/src/components/checkbox/model.ts
+++ b/packages/components/src/components/checkbox/model.ts
@@ -1,4 +1,4 @@
-import {
+import type {
 	ChangeEventProps,
 	ChangeEventState,
 	FocusEventProps,

--- a/packages/components/src/components/custom-button/model.ts
+++ b/packages/components/src/components/custom-button/model.ts
@@ -1,4 +1,4 @@
-import {
+import type {
 	GlobalProps,
 	GlobalState,
 	IconLeadingProps,
@@ -12,7 +12,7 @@ import {
 	WidthProps,
 	WrapProps
 } from '../../shared/model';
-import { DBButtonSharedProps } from '../button/model';
+import type { DBButtonSharedProps } from '../button/model';
 
 export type DBCustomButtonDefaultProps = {};
 

--- a/packages/components/src/components/custom-select-dropdown/model.ts
+++ b/packages/components/src/components/custom-select-dropdown/model.ts
@@ -1,4 +1,4 @@
-import { GlobalProps, GlobalState } from '../../shared/model';
+import type { GlobalProps, GlobalState } from '../../shared/model';
 
 export const CustomSelectDropdownWidthList = ['fixed', 'auto', 'full'] as const;
 export type CustomSelectDropdownWidthType =

--- a/packages/components/src/components/custom-select-form-field/model.ts
+++ b/packages/components/src/components/custom-select-form-field/model.ts
@@ -1,4 +1,4 @@
-import { GlobalProps, GlobalState } from '../../shared/model';
+import type { GlobalProps, GlobalState } from '../../shared/model';
 
 export type DBCustomSelectFormFieldDefaultProps = {};
 

--- a/packages/components/src/components/custom-select-list-item/model.ts
+++ b/packages/components/src/components/custom-select-list-item/model.ts
@@ -1,4 +1,4 @@
-import {
+import type {
 	BaseFormProps,
 	ChangeEventProps,
 	ChangeEventState,

--- a/packages/components/src/components/custom-select-list/model.ts
+++ b/packages/components/src/components/custom-select-list/model.ts
@@ -1,4 +1,4 @@
-import { GlobalProps, GlobalState } from '../../shared/model';
+import type { GlobalProps, GlobalState } from '../../shared/model';
 
 export type DBCustomSelectListDefaultProps = {
 	label?: string;

--- a/packages/components/src/components/custom-select/model.ts
+++ b/packages/components/src/components/custom-select/model.ts
@@ -1,4 +1,4 @@
-import {
+import type {
 	BaseFormProps,
 	ClickEvent,
 	CloseEventState,
@@ -20,9 +20,9 @@ import {
 	ValidationType,
 	WidthType
 } from '../../shared/model';
-import { CustomSelectDropdownWidthType } from '../custom-select-dropdown/model';
-import { DBCustomSelectFormFieldDefaultProps } from '../custom-select-form-field/model';
-import { DBCustomSelectListItemExtraProps } from '../custom-select-list-item/model';
+import type { CustomSelectDropdownWidthType } from '../custom-select-dropdown/model';
+import type { DBCustomSelectFormFieldDefaultProps } from '../custom-select-form-field/model';
+import type { DBCustomSelectListItemExtraProps } from '../custom-select-list-item/model';
 
 export type CustomSelectOptionType = {
 	/**

--- a/packages/components/src/components/divider/model.ts
+++ b/packages/components/src/components/divider/model.ts
@@ -1,4 +1,4 @@
-import {
+import type {
 	EmphasisProps,
 	GlobalProps,
 	GlobalState,

--- a/packages/components/src/components/drawer/model.ts
+++ b/packages/components/src/components/drawer/model.ts
@@ -1,4 +1,4 @@
-import {
+import type {
 	ClickEvent,
 	CloseEventProps,
 	CloseEventState,

--- a/packages/components/src/components/header/model.ts
+++ b/packages/components/src/components/header/model.ts
@@ -1,4 +1,4 @@
-import {
+import type {
 	ContainerWidthProps,
 	GlobalProps,
 	GlobalState,

--- a/packages/components/src/components/icon/model.ts
+++ b/packages/components/src/components/icon/model.ts
@@ -1,4 +1,4 @@
-import {
+import type {
 	GlobalProps,
 	GlobalState,
 	IconProps,

--- a/packages/components/src/components/infotext/model.ts
+++ b/packages/components/src/components/infotext/model.ts
@@ -1,4 +1,4 @@
-import {
+import type {
 	GlobalProps,
 	GlobalState,
 	IconProps,

--- a/packages/components/src/components/input/model.ts
+++ b/packages/components/src/components/input/model.ts
@@ -1,4 +1,4 @@
-import {
+import type {
 	ChangeEventProps,
 	ChangeEventState,
 	FocusEventProps,

--- a/packages/components/src/components/link/model.ts
+++ b/packages/components/src/components/link/model.ts
@@ -1,4 +1,4 @@
-import {
+import type {
 	ClickEventProps,
 	ClickEventState,
 	GlobalProps,

--- a/packages/components/src/components/navigation-item/model.ts
+++ b/packages/components/src/components/navigation-item/model.ts
@@ -1,4 +1,4 @@
-import {
+import type {
 	ClickEvent,
 	ClickEventProps,
 	ClickEventState,
@@ -13,7 +13,7 @@ import {
 	WidthProps,
 	WrapProps
 } from '../../shared/model';
-import { NavigationItemSafeTriangle } from '../../utils/navigation';
+import type { NavigationItemSafeTriangle } from '../../utils/navigation';
 
 export type DBNavigationItemDefaultProps = {
 	/**

--- a/packages/components/src/components/navigation/model.ts
+++ b/packages/components/src/components/navigation/model.ts
@@ -1,4 +1,4 @@
-import { GlobalProps } from '../../shared/model';
+import type { GlobalProps } from '../../shared/model';
 
 export type DBNavigationDefaultProps = {};
 

--- a/packages/components/src/components/notification/model.ts
+++ b/packages/components/src/components/notification/model.ts
@@ -1,4 +1,4 @@
-import {
+import type {
 	ClickEvent,
 	CloseEventProps,
 	CloseEventState,

--- a/packages/components/src/components/page/model.ts
+++ b/packages/components/src/components/page/model.ts
@@ -1,4 +1,4 @@
-import { GlobalProps, GlobalState } from '../../shared/model';
+import type { GlobalProps, GlobalState } from '../../shared/model';
 
 export const PageVariantList = ['auto', 'fixed'] as const;
 export type PageVariantType = (typeof PageVariantList)[number];

--- a/packages/components/src/components/popover/model.ts
+++ b/packages/components/src/components/popover/model.ts
@@ -1,4 +1,4 @@
-import {
+import type {
 	GapProps,
 	GlobalProps,
 	GlobalState,

--- a/packages/components/src/components/radio/model.ts
+++ b/packages/components/src/components/radio/model.ts
@@ -1,4 +1,4 @@
-import {
+import type {
 	ChangeEventProps,
 	ChangeEventState,
 	FocusEventProps,

--- a/packages/components/src/components/section/model.ts
+++ b/packages/components/src/components/section/model.ts
@@ -1,4 +1,4 @@
-import {
+import type {
 	ContainerWidthProps,
 	GlobalProps,
 	SpacingProps

--- a/packages/components/src/components/select/model.ts
+++ b/packages/components/src/components/select/model.ts
@@ -1,4 +1,4 @@
-import {
+import type {
 	ChangeEventProps,
 	ChangeEventState,
 	ClickEventProps,

--- a/packages/components/src/components/stack/model.ts
+++ b/packages/components/src/components/stack/model.ts
@@ -1,4 +1,8 @@
-import { GapSpacingProps, GlobalProps, GlobalState } from '../../shared/model';
+import type {
+	GapSpacingProps,
+	GlobalProps,
+	GlobalState
+} from '../../shared/model';
 
 export const StackVariantList = ['simple', 'divider'] as const;
 export type StackVariantType = (typeof StackVariantList)[number];

--- a/packages/components/src/components/switch/model.ts
+++ b/packages/components/src/components/switch/model.ts
@@ -1,4 +1,4 @@
-import {
+import type {
 	ChangeEventProps,
 	ChangeEventState,
 	FocusEventProps,

--- a/packages/components/src/components/tab-item/model.ts
+++ b/packages/components/src/components/tab-item/model.ts
@@ -1,4 +1,4 @@
-import {
+import type {
 	ActiveProps,
 	ChangeEventProps,
 	ChangeEventState,

--- a/packages/components/src/components/tab-list/model.ts
+++ b/packages/components/src/components/tab-list/model.ts
@@ -1,4 +1,4 @@
-import { GlobalProps } from '../../shared/model';
+import type { GlobalProps } from '../../shared/model';
 
 export type DBTabListDefaultProps = {};
 

--- a/packages/components/src/components/tab-panel/model.ts
+++ b/packages/components/src/components/tab-panel/model.ts
@@ -1,4 +1,4 @@
-import { GlobalProps, GlobalState } from '../../shared/model';
+import type { GlobalProps, GlobalState } from '../../shared/model';
 
 export type DBTabPanelDefaultProps = {
 	/**

--- a/packages/components/src/components/tabs/model.ts
+++ b/packages/components/src/components/tabs/model.ts
@@ -1,4 +1,4 @@
-import {
+import type {
 	AlignmentProps,
 	GlobalProps,
 	InitializedState,
@@ -6,8 +6,8 @@ import {
 	OrientationProps,
 	WidthProps
 } from '../../shared/model';
-import { DBTabItemProps } from '../tab-item/model';
-import { DBTabPanelProps } from '../tab-panel/model';
+import type { DBTabItemProps } from '../tab-item/model';
+import type { DBTabPanelProps } from '../tab-panel/model';
 
 export const TabsBehaviorList = ['scrollbar', 'arrows'] as const;
 export type TabsBehaviorType = (typeof TabsBehaviorList)[number];

--- a/packages/components/src/components/tag/model.ts
+++ b/packages/components/src/components/tag/model.ts
@@ -1,4 +1,4 @@
-import {
+import type {
 	ClickEvent,
 	ContentSlotProps,
 	EmphasisProps,

--- a/packages/components/src/components/textarea/model.ts
+++ b/packages/components/src/components/textarea/model.ts
@@ -1,4 +1,4 @@
-import {
+import type {
 	ChangeEventProps,
 	ChangeEventState,
 	FocusEventProps,

--- a/packages/components/src/components/tooltip/model.ts
+++ b/packages/components/src/components/tooltip/model.ts
@@ -1,4 +1,4 @@
-import {
+import type {
 	ClickEventState,
 	DocumentScrollState,
 	EmphasisProps,


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

use `import type` for type-only imports in all component models

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improvements to existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/fix-add-type-for-model-imports>

<!-- DBUX-TEST-URL-END -->