### PR TITLE
chore: improve TruffleHog configuration for better scanning speed

### DIFF
--- a/.github/workflows/00-init.yml
+++ b/.github/workflows/00-init.yml
@@ -61,15 +61,13 @@ jobs:
           fetch-depth: 0
           fetch-tags: false
 
-      # https://github.com/marketplace/actions/trufflehog-oss#advanced-usage-scan-entire-branch
+      # https://github.com/marketplace/actions/trufflehog-oss#general-usage
       - name: 🐷 TruffleHog OSS
         if: ${{ github.event.pull_request != null && github.event.pull_request.head.repo.owner.login == 'db-ux-design-system' }} # only scan on pull-requests
         uses: trufflesecurity/trufflehog@main
         with:
-          # Setting base to an empty string scans the entire branch, per TruffleHog OSS advanced usage:
-          # https://github.com/marketplace/actions/trufflehog-oss#advanced-usage-scan-entire-branch
-          base: ""
-          head: ${{ github.ref_name }}
+          base: ${{ github.event.pull_request.base.sha }}
+          head: ${{ github.event.pull_request.head.sha }}
           extra_args: --results=verified,unknown
 
       - name: 🔄 Init Cache Default


### PR DESCRIPTION
## Proposed changes


What
Limit TruffleHog scanning to only the commits changed in a PR instead of scanning the entire branch history.

Why
The previous config used base: "" which triggers a full branch scan — this is the slowest possible mode and unnecessary for PR checks where we only care about newly introduced secrets.

Changes
Replace base: "" / head: ${{ github.ref_name }} with base: ${{ github.event.pull_request.base.sha }} / head: ${{ github.event.pull_request.head.sha }}

TruffleHog now only diffs between the PR base and head commits

No functional change — secrets are still detected, just faster.
## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improvements to existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

<!-- ## Checklist

_Put an `x` in the boxes that apply.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

❤️ Thank you!
-->
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/chore-imporve-trufflehog-speed>

<!-- DBUX-TEST-URL-END -->