### PR TITLE
fix(drawer): stabilize flaky NVDA screen-reader test for autofocus timing

### DIFF
--- a/showcases/screen-reader/default.ts
+++ b/showcases/screen-reader/default.ts
@@ -80,6 +80,8 @@ const cleanSpeakInstructions = (phraseLog: string[]): string[] =>
 		return result;
 	});
 
+export const STABILIZATION_DELAY = 1000;
+
 export const generateSnapshot = async (
 	screenReader?: VoiceOverPlaywright | NVDAPlaywright,
 	retry?: number,

--- a/showcases/screen-reader/tests/drawer.spec.ts
+++ b/showcases/screen-reader/tests/drawer.spec.ts
@@ -1,4 +1,9 @@
-import { generateSnapshot, getTest, testDefault } from '../default';
+import {
+	generateSnapshot,
+	getTest,
+	STABILIZATION_DELAY,
+	testDefault
+} from '../default';
 
 const test = getTest();
 
@@ -8,9 +13,10 @@ test.describe('DBDrawer', () => {
 		title: 'autofocus',
 		description: 'should autofocus',
 		url: './#/01/drawer?page=density',
-		async testFn(voiceOver, nvda) {
+		async testFn(voiceOver, nvda, page) {
 			const screenReader = voiceOver ?? nvda;
 			await screenReader?.act();
+			await page.waitForTimeout(STABILIZATION_DELAY);
 			await screenReader?.next();
 		},
 		async postTestFn(voiceOver, nvda, retry) {
@@ -24,6 +30,11 @@ test.describe('DBDrawer', () => {
 						log
 							.replace('Showcase, document. unknown', 'button')
 							.replace('unknown', 'button')
+							// Autofocus timing: NVDA sometimes prepends "button." to the dialog announcement
+							.replace(
+								'button. dialog. document',
+								'dialog. document'
+							)
 					)
 				);
 			} else if (voiceOver) {


### PR DESCRIPTION
Fixes intermittent failures in the Drawer autofocus screen-reader test on Windows CI.
NVDA has a timing issue where it sometimes prepends "button." to the dialog announcement when autofocus triggers. This adds a string normalization to the snapshot comparison to handle this race condition consistently.

## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

resolves # (issue number)

## Types of changes

<!-- What types of changes does your code introduce?
_Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improvements to existing components or architectural decisions)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
