### PR TITLE
feat: add html-storybook with rendered HTML output in Show Code panel

### DIFF
--- a/.github/workflows/01-build-storybooks.yml
+++ b/.github/workflows/01-build-storybooks.yml
@@ -47,11 +47,18 @@ jobs:
           path: packages/components/build
 
       - name: ⏫ Download stories
-        if: ${{ inputs.storybook != 'composition-storybook' }}
+        if: ${{ inputs.storybook != 'composition-storybook' && inputs.storybook != 'html-storybook' }}
         uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.storybook }}-stories
           path: storybooks/${{ inputs.storybook }}/src/components
+
+      - name: ⏫ Download stories for html-storybook
+        if: ${{ inputs.storybook == 'html-storybook' }}
+        uses: actions/download-artifact@v8
+        with:
+          name: react-storybook-stories
+          path: storybooks/react-storybook/src/components
 
       - name: 🔨 Build ${{ inputs.storybook }}
         env:

--- a/.github/workflows/03-deploy-gh-pages.yml
+++ b/.github/workflows/03-deploy-gh-pages.yml
@@ -74,6 +74,12 @@ jobs:
           name: db-ux-vue-storybook
           path: build-storybooks/vue-storybook
 
+      - name: ⏬ Download html-storybook
+        uses: actions/download-artifact@v8
+        with:
+          name: db-ux-html-storybook
+          path: build-storybooks/html-storybook
+
       - name: 🦵🦿 I like to move it move it
         shell: bash
         run: |

--- a/.github/workflows/03-deploy-gh-pages.yml
+++ b/.github/workflows/03-deploy-gh-pages.yml
@@ -86,6 +86,7 @@ jobs:
           mv build-showcases/patternhub out
           mv build-storybooks/composition-storybook out/composition-storybook
           mv build-storybooks/angular-storybook out/angular-storybook
+          mv build-storybooks/html-storybook out/html-storybook
           mv build-storybooks/react-storybook out/react-storybook
           mv build-storybooks/vue-storybook out/vue-storybook
 

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -165,6 +165,14 @@ jobs:
       baseUrl: ${{ needs.init.outputs.baseUrl }}
     secrets: inherit
 
+  build-storybook-html:
+    uses: ./.github/workflows/01-build-storybooks.yml
+    needs: [build-packages, init, build-stories]
+    with:
+      storybook: html-storybook
+      baseUrl: ${{ needs.init.outputs.baseUrl }}
+    secrets: inherit
+
   build-showcase-stencil:
     uses: ./.github/workflows/01-build-showcases.yml
     needs: [build-packages, init]
@@ -414,6 +422,7 @@ jobs:
           fi
           resultBuildStorybookComposition="${{ needs.build-storybook-composition.result }}"
           resultBuildStorybookAngular="${{ needs.build-storybook-angular.result }}"
+          resultBuildStorybookHtml="${{ needs.build-storybook-html.result }}"
           resultBuildStorybookReact="${{ needs.build-storybook-react.result }}"
           resultBuildStorybookVue="${{ needs.build-storybook-vue.result }}"
           resultBuildShowcaseStencil="${{ needs.build-showcase-stencil.result }}"
@@ -438,6 +447,7 @@ jobs:
 
           echo "resultBuildStorybookComposition: $resultBuildStorybookComposition"
           echo "resultBuildStorybookAngular: $resultBuildStorybookAngular"
+          echo "resultBuildStorybookHtml: $resultBuildStorybookHtml"
           echo "resultBuildStorybookReact: $resultBuildStorybookReact"
           echo "resultBuildStorybookVue: $resultBuildStorybookVue"
           echo "resultBuildShowcaseStencil: $resultBuildShowcaseStencil"
@@ -460,6 +470,7 @@ jobs:
 
           if [[ $resultBuildStorybookComposition == "success" ]] && \
              [[ $resultBuildStorybookAngular == "success" ]] && \
+             [[ $resultBuildStorybookHtml == "success" ]] && \
              [[ $resultBuildStorybookReact == "success" ]] && \
              [[ $resultBuildStorybookVue == "success" ]] && \
              [[ $resultTestFoundations == "success" ]] && \
@@ -491,6 +502,7 @@ jobs:
       [
         build-storybook-composition,
         build-storybook-angular,
+        build-storybook-html,
         build-storybook-react,
         build-storybook-vue,
         build-showcase-stencil,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1393,6 +1393,70 @@ importers:
         specifier: 10.4.1
         version: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
+  storybooks/html-storybook:
+    dependencies:
+      '@db-ux/db-theme':
+        specifier: 5.7.0
+        version: 5.7.0
+      '@db-ux/db-theme-fonts':
+        specifier: 2.0.5
+        version: 2.0.5
+      '@db-ux/db-theme-icons':
+        specifier: 3.9.0
+        version: 3.9.0
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: 19.2.7
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@eslint/js':
+        specifier: 10.0.1
+        version: 10.0.1(eslint@10.4.1(jiti@2.7.0))
+      '@storybook/addon-docs':
+        specifier: 10.4.1
+        version: 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.1(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
+      '@storybook/react-vite':
+        specifier: 10.4.1
+        version: 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(esbuild@0.28.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.4)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.1(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
+      '@types/react':
+        specifier: 19.2.16
+        version: 19.2.16
+      '@types/react-dom':
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.16)
+      '@vitejs/plugin-react':
+        specifier: 6.0.2
+        version: 6.0.2(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      eslint:
+        specifier: 10.4.1
+        version: 10.4.1(jiti@2.7.0)
+      eslint-plugin-react-refresh:
+        specifier: 0.5.2
+        version: 0.5.2(eslint@10.4.1(jiti@2.7.0))
+      eslint-plugin-storybook:
+        specifier: 10.4.1
+        version: 10.4.1(eslint@10.4.1(jiti@2.7.0))(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)
+      globals:
+        specifier: 17.6.0
+        version: 17.6.0
+      prettier:
+        specifier: 3.8.3
+        version: 3.8.3
+      storybook:
+        specifier: 10.4.1
+        version: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.60.1
+        version: 8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@5.9.3)
+      vite:
+        specifier: 8.0.16
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+
   storybooks/react-storybook:
     dependencies:
       '@db-ux/db-theme':

--- a/storybooks/_storybook/.storybook/main.ts
+++ b/storybooks/_storybook/.storybook/main.ts
@@ -31,6 +31,7 @@ const config: StorybookConfig = {
 			angular: isDev
 				? 'http://localhost:6006'
 				: `${baseUrl}/angular-storybook`,
+			html: isDev ? 'http://localhost:6008' : `${baseUrl}/html-storybook`,
 			react: isDev
 				? 'http://localhost:6005'
 				: `${baseUrl}/react-storybook`,
@@ -57,6 +58,11 @@ const config: StorybookConfig = {
 					url: 'http://localhost:6006',
 					expanded: false
 				},
+				html: {
+					title: 'HTML',
+					url: 'http://localhost:6008',
+					expanded: false
+				},
 				react: {
 					title: 'React',
 					url: 'http://localhost:6005',
@@ -73,6 +79,11 @@ const config: StorybookConfig = {
 			angular: {
 				title: 'Angular',
 				url: `${baseUrl}/angular-storybook`,
+				expanded: false
+			},
+			html: {
+				title: 'HTML',
+				url: `${baseUrl}/html-storybook`,
 				expanded: false
 			},
 			react: {

--- a/storybooks/html-storybook/.storybook/global.css
+++ b/storybooks/html-storybook/.storybook/global.css
@@ -1,0 +1,8 @@
+@layer db-ux, db-theme;
+
+@import "@db-ux/core-components/build/styles/rollup.css" layer(db-ux);
+@import "@db-ux/db-theme/build/styles/rollup.css" layer(db-theme);
+
+.docs-story {
+	background-color: var(--db-adaptive-bg-basic-level-1-default);
+}

--- a/storybooks/html-storybook/.storybook/html-capture-decorator.tsx
+++ b/storybooks/html-storybook/.storybook/html-capture-decorator.tsx
@@ -1,0 +1,25 @@
+import type { Decorator } from '@storybook/react-vite';
+import { useEffect, useRef } from 'react';
+
+/**
+ * Global map storing captured innerHTML for each story.
+ * Keyed by Storybook story ID (e.g., "components-button--primary").
+ */
+export const htmlSourceMap = new Map<string, string>();
+
+export const htmlCaptureDecorator: Decorator = (Story, context) => {
+	const containerRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		if (containerRef.current) {
+			const html = containerRef.current.innerHTML;
+			htmlSourceMap.set(context.id, html);
+		}
+	});
+
+	return (
+		<div ref={containerRef} style={{ display: 'contents' }}>
+			<Story />
+		</div>
+	);
+};

--- a/storybooks/html-storybook/.storybook/html-capture-decorator.tsx
+++ b/storybooks/html-storybook/.storybook/html-capture-decorator.tsx
@@ -15,7 +15,7 @@ export const htmlCaptureDecorator: Decorator = (Story, context) => {
 			const html = containerRef.current.innerHTML;
 			htmlSourceMap.set(context.id, html);
 		}
-	});
+	}, [context.id]);
 
 	return (
 		<div ref={containerRef} style={{ display: 'contents' }}>

--- a/storybooks/html-storybook/.storybook/main.ts
+++ b/storybooks/html-storybook/.storybook/main.ts
@@ -1,0 +1,37 @@
+import type { StorybookConfig } from '@storybook/react-vite';
+import { createRequire } from 'node:module';
+
+import { dirname, join } from 'node:path';
+
+const require = createRequire(import.meta.url);
+
+/**
+ * This function is used to resolve the absolute path of a package.
+ * It is needed in projects that use Yarn PnP or are set up within a monorepo.
+ */
+function getAbsolutePath(value: string): string {
+	return dirname(require.resolve(join(value, 'package.json')));
+}
+const config: StorybookConfig = {
+	stories: [
+		'../../react-storybook/src/**/*.mdx',
+		'../../react-storybook/src/**/*.stories.@(js|jsx|mjs|ts|tsx)'
+	],
+	addons: ['@storybook/addon-docs'],
+	staticDirs: ['../../react-storybook/public'],
+	framework: {
+		name: getAbsolutePath('@storybook/react-vite'),
+		options: {}
+	},
+	async viteFinal(config) {
+		const { mergeConfig } = await import('vite');
+		const baseUrl = process.env.BASE_URL || '';
+		return mergeConfig(config, {
+			base: `${baseUrl}/html-storybook`,
+			build: {
+				cssMinify: 'esbuild'
+			}
+		});
+	}
+};
+export default config;

--- a/storybooks/html-storybook/.storybook/preview.ts
+++ b/storybooks/html-storybook/.storybook/preview.ts
@@ -1,0 +1,44 @@
+import type { Preview } from '@storybook/react-vite';
+import * as prettierHtml from 'prettier/plugins/html';
+import * as prettier from 'prettier/standalone';
+import './global.css';
+import { htmlCaptureDecorator, htmlSourceMap } from './html-capture-decorator';
+
+const preview: Preview = {
+	decorators: [htmlCaptureDecorator],
+	parameters: {
+		controls: {
+			matchers: {
+				color: /(background|color)$/i,
+				date: /Date$/i
+			},
+			disable: true
+		},
+		docs: {
+			toc: {
+				headingSelector: 'h1, h3',
+				title: 'Table of Contents'
+			},
+			source: {
+				transform: async (
+					_code: string,
+					storyContext: { id: string }
+				) => {
+					const html = htmlSourceMap.get(storyContext.id);
+					if (!html) {
+						return '<!-- HTML output not available -->';
+					}
+					return prettier.format(html, {
+						parser: 'html',
+						plugins: [prettierHtml],
+						useTabs: true,
+						printWidth: 80
+					});
+				},
+				language: 'html'
+			}
+		}
+	}
+};
+
+export default preview;

--- a/storybooks/html-storybook/package.json
+++ b/storybooks/html-storybook/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "html-storybook",
+  "version": "0.0.0",
+  "type": "module",
+  "description": "HTML storybook - shows rendered HTML output for React stories",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/db-ux-design-system/core-web.git"
+  },
+  "license": "Apache-2.0",
+  "private": true,
+  "scripts": {
+    "build": "storybook build --output-dir ../../build-storybooks/html-storybook",
+    "storybook": "storybook dev -p 6008"
+  },
+  "dependencies": {
+    "@db-ux/db-theme": "5.7.0",
+    "@db-ux/db-theme-fonts": "2.0.5",
+    "@db-ux/db-theme-icons": "3.9.0",
+    "react": "19.2.7",
+    "react-dom": "19.2.7"
+  },
+  "devDependencies": {
+    "@eslint/js": "10.0.1",
+    "@storybook/addon-docs": "10.4.1",
+    "@storybook/react-vite": "10.4.1",
+    "@types/react": "19.2.16",
+    "@types/react-dom": "19.2.3",
+    "@vitejs/plugin-react": "6.0.2",
+    "eslint": "10.4.1",
+    "eslint-plugin-react-refresh": "0.5.2",
+    "eslint-plugin-storybook": "10.4.1",
+    "globals": "17.6.0",
+    "prettier": "3.8.3",
+    "storybook": "10.4.1",
+    "typescript": "~5.9.3",
+    "typescript-eslint": "^8.60.1",
+    "vite": "8.0.16"
+  }
+}

--- a/storybooks/html-storybook/vite.config.ts
+++ b/storybooks/html-storybook/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
 	plugins: [react()],
 	resolve: {
 		alias: {
-			// Wired issue with storybook vite-builder inside monorepo
+			// Weird issue with storybook vite-builder inside monorepo
 			vue: path.resolve(__dirname, '../../node_modules/vue'),
 			// eslint-disable-next-line @typescript-eslint/naming-convention
 			'@components': path.resolve(__dirname, '../../output/react/src')

--- a/storybooks/html-storybook/vite.config.ts
+++ b/storybooks/html-storybook/vite.config.ts
@@ -1,0 +1,23 @@
+import react from '@vitejs/plugin-react';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vite';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename).replaceAll('\\', '/');
+
+// https://vite.dev/config/
+export default defineConfig({
+	plugins: [react()],
+	resolve: {
+		alias: {
+			// Wired issue with storybook vite-builder inside monorepo
+			vue: path.resolve(__dirname, '../../node_modules/vue'),
+			// eslint-disable-next-line @typescript-eslint/naming-convention
+			'@components': path.resolve(__dirname, '../../output/react/src')
+		}
+	},
+	build: {
+		cssMinify: 'esbuild'
+	}
+});


### PR DESCRIPTION
Adds a new Storybook instance that reuses react-storybook stories and displays prettified HTML (via prettier/standalone) instead of JSX in the code panel. Includes CI build job, composition storybook integration, and checks-done gate. Controls/props panel is disabled since React properties are irrelevant for HTML output.

## Proposed changes

resolves # (issue number)

## Checklist

### Code Quality

- [x] I have reviewed my own code (self-review), including the screen- and snapshots
- [x] I have reviewed my changes locally with an AI assistant (e.g. GitHub Copilot, Kiro, etc.)
- [x] No hardcoded values, magic numbers, or debug code left in

### Validation

- [ ] I have added/updated tests that cover my changes
- [ ] I have tested across all relevant frameworks (React, Angular, Vue) if applicable

### General

- [x] The PR title follows the conventional commits format (e.g. `feat:`, `fix:`, `chore:`), as in [Git Commit Conventions](docs/conventions.md#git-commits-conventions)
- [ ] If architecture, structure, or conventions changed inside a `packages/*` folder, the corresponding `AGENTS.md` has been updated
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/docs-html-storybook>

<!-- DBUX-TEST-URL-END -->