### PR TITLE
feat(showcase): show storybook link for `html`

### DIFF
--- a/showcases/patternhub/components/framework-switcher/framework-switcher.tsx
+++ b/showcases/patternhub/components/framework-switcher/framework-switcher.tsx
@@ -13,7 +13,7 @@ const FrameworkSwitcher = () => {
 			value={framework}
 			onChange={(event) => {
 				const { value } = event.target;
-				if (['angular', 'react', 'vue'].includes(value)) {
+				if (['angular', 'html', 'react', 'vue'].includes(value)) {
 					setFramework(value as Framework);
 				}
 			}}>


### PR DESCRIPTION
Reverts db-ux-design-system/core-web#6570

As a followup to https://github.com/db-ux-design-system/core-web/pull/6911, we could show the "show code" link for HTML storybook again.
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/revert-6570-fix-showcase-hide-storybook-link-for-html>

<!-- DBUX-TEST-URL-END -->