### PR TITLE
feat: added possibility for triggering the default pipeline individually

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -355,6 +355,7 @@ jobs:
   test-screen-reader:
     if: |
       github.event_name == 'release' ||
+      github.event_name == 'workflow_dispatch' ||
       needs.init.outputs.test-ally == 'true' ||
       github.event.pull_request == null
     uses: ./.github/workflows/02-e2e-screen-reader.yml

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -14,6 +14,7 @@ on:
       - "main"
   release:
     types: [published]
+  workflow_dispatch:
 
 # We'd like to run the pipeline for Dependabot PRs sequentially, and all other PRs in parallel, but still only one action run for each PR.
 # TODO: We won't need this anymore as soon as we get Merge Groups and could remove the concurrency again, which currently brings us pain regarding unstarted, non-self-healing dependabot pipelines

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -323,7 +323,7 @@ jobs:
       baseUrl: ${{ needs.init.outputs.baseUrl }}
 
   regenerate-snapshots-components:
-    if: ${{ github.event_name != 'release' && !cancelled() && needs.test-components.result == 'failure' }}
+    if: ${{ github.event_name == 'pull_request' && !cancelled() && needs.test-components.result == 'failure' }}
     uses: ./.github/workflows/02-e2e-regenerate.yml
     secrets: inherit
     with:
@@ -332,7 +332,7 @@ jobs:
     needs: [test-components, init]
 
   regenerate-snapshots-foundations:
-    if: ${{ github.event_name != 'release' && !cancelled() && needs.test-foundations.result == 'failure' }}
+    if: ${{ github.event_name == 'pull_request' && !cancelled() && needs.test-foundations.result == 'failure' }}
     uses: ./.github/workflows/02-e2e-regenerate.yml
     secrets: inherit
     with:
@@ -341,7 +341,7 @@ jobs:
     needs: [test-foundations, init]
 
   regenerate-snapshots-patternhub:
-    if: ${{ github.event_name != 'release' && !cancelled() && needs.test-showcase-patternhub.result == 'failure' }}
+    if: ${{ github.event_name == 'pull_request' && !cancelled() && needs.test-showcase-patternhub.result == 'failure' }}
     uses: ./.github/workflows/02-e2e-regenerate.yml
     secrets: inherit
     with:
@@ -366,7 +366,7 @@ jobs:
 
   regenerate-snapshots:
     if: |
-      github.event_name != 'release' && !cancelled() && !contains(github.actor,'[bot]') && (
+      github.event_name == 'pull_request' && !cancelled() && !contains(github.actor,'[bot]') && (
         needs.test-showcase-angular.result == 'failure' ||
         needs.test-showcase-react.result == 'failure' ||
         needs.test-showcase-vue.result == 'failure' ||
@@ -390,7 +390,7 @@ jobs:
     uses: ./.github/workflows/02-e2e-regenerated-snapshots-commit.yml
     secrets: inherit
     if: |
-      ${{ github.event_name != 'release' && !cancelled() &&
+      ${{ github.event_name == 'pull_request' && !cancelled() &&
         ( needs.regenerate-snapshots-components.result == 'success' ||
         needs.regenerate-snapshots-foundations.result == 'success' ||
         needs.regenerate-snapshots-patternhub.result == 'success' ||


### PR DESCRIPTION
## Proposed changes

We'd like to be able to trigger our `default` workflow manually, e.g. from a specific branch context, as well as even also run the screen-reader tests in this branch context for QA reasons, emulating the full pipeline in `main` default branch.

## Checklist

### Code Quality

- [x] I have reviewed my own code (self-review), including the screen- and snapshots
- [x] I have reviewed my changes locally with an AI assistant (e.g. GitHub Copilot, Kiro, etc.)
- [x] No hardcoded values, magic numbers, or debug code left in

### Validation

- [ ] ~I have added/updated tests that cover my changes~
- [ ] ~I have tested across all relevant frameworks (React, Angular, Vue) if applicable~

### General

- [x] The PR title follows the conventional commits format (e.g. `feat:`, `fix:`, `chore:`), as in [Git Commit Conventions](docs/conventions.md#git-commits-conventions)
- [ ] If architecture, structure, or conventions changed inside a `packages/*` folder, the corresponding `AGENTS.md` has been updated
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/feat-added-possibility-for-triggering-the-default-pipeline-individually>

<!-- DBUX-TEST-URL-END -->