### PR TITLE
fix(`AGENTS.md`): changeset major release handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,8 +114,8 @@ This repository uses [Changesets](https://github.com/changesets/changesets) to m
 Use the following bump types for changeset entries:
 
 - **`patch`** — for bug fixes
-- **`minor`** — for new features
-- **`major`** — for breaking changes (e.g. a property in any `model.ts` has been added, removed, renamed, or its type has changed)
+- **`minor`** — for new features (e.g. a property in any `model.ts` has been added)
+- **`major`** — for breaking changes (e.g. a property in any `model.ts` has been removed, renamed, or its type has changed)
 
 ### How to Add a Changeset
 

--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -89,7 +89,7 @@ Stories are generated from the `examples/` folder via the `configs/plugins/story
 1. Use `pnpm run generate:component` to scaffold — never create component folders manually
 2. **Check `src/shared/model.ts` first** before adding any new prop — it may already exist as a shared type (see Shared Props section below)
 3. **Check other `**/model.ts`files** — if a similar prop exists in another component, consider moving it to`src/shared/model.ts` before reusing it
-4. Edit `model.ts` for prop changes (breaking change if props are added/removed/renamed/retyped → needs `major` changeset)
+4. Edit `model.ts` for prop changes (breaking change if props are removed/renamed/retyped → needs `major` changeset; if props are added → needs `minor` changeset)
 5. Edit the `.lite.tsx` for template/logic changes
 6. **Check `src/styles/internal/` first** before writing new SCSS — the style may already exist as a shared internal mixin/placeholder (see Shared Styles section below)
 7. Edit the `.scss` for style changes

--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -160,5 +160,5 @@ Changes in `packages/components/src` require a changeset for:
 `@db-ux/core-components`, `@db-ux/ngx-core-components`, `@db-ux/react-core-components`, `@db-ux/wc-core-components`, `@db-ux/v-core-components`
 
 - `patch` — bug fix
-- `minor` — new feature or example
-- `major` — any prop in `model.ts` added, removed, renamed, or retyped
+- `minor` — new feature or example, or any prop added in `model.ts`
+- `major` — any prop in `model.ts` removed, renamed, or retyped


### PR DESCRIPTION
## Proposed changes

Currently we're stating that an added prop would need a major release. This contradicts other documentation and on what we've aligned, so this needs to get corrected.

## Checklist

### Code Quality

- [x] I have reviewed my own code (self-review), including the screen- and snapshots
- [x] I have reviewed my changes locally with an AI assistant (e.g. GitHub Copilot, Kiro, etc.)
- [x] No hardcoded values, magic numbers, or debug code left in

### Validation

- [ ] ~I have added/updated tests that cover my changes~
- [ ] ~I have tested across all relevant frameworks (React, Angular, Vue) if applicable~

### General

- [x] The PR title follows the conventional commits format (e.g. `feat:`, `fix:`, `chore:`), as in [Git Commit Conventions](docs/conventions.md#git-commits-conventions)
- [ ] If architecture, structure, or conventions changed inside a `packages/*` folder, the corresponding `AGENTS.md` has been updated
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/fix-agents-md-changeset-major-release-handling>

<!-- DBUX-TEST-URL-END -->