### PR TITLE
ci: remove TruffleHog OSS in favor of GitHub Secret Scanning

### DIFF
--- a/.github/workflows/00-init.yml
+++ b/.github/workflows/00-init.yml
@@ -61,17 +61,6 @@ jobs:
           fetch-depth: 0
           fetch-tags: false
 
-      # https://github.com/marketplace/actions/trufflehog-oss#advanced-usage-scan-entire-branch
-      - name: 🐷 TruffleHog OSS
-        if: ${{ github.event.pull_request != null && github.event.pull_request.head.repo.owner.login == 'db-ux-design-system' }} # only scan on pull-requests
-        uses: trufflesecurity/trufflehog@main
-        with:
-          # Setting base to an empty string scans the entire branch, per TruffleHog OSS advanced usage:
-          # https://github.com/marketplace/actions/trufflehog-oss#advanced-usage-scan-entire-branch
-          base: ""
-          head: ${{ github.ref_name }}
-          extra_args: --results=verified,unknown
-
       - name: 🔄 Init Cache Default
         uses: ./.github/actions/pnpm-cache
         env:


### PR DESCRIPTION
## Proposed changes

Removes the TruffleHog OSS step from the init workflow (`00-init.yml`) and replaces it with GitHub's native Secret Scanning + Push Protection.

**Why:**
- TruffleHog scans the entire branch on every PR, spinning up a Docker container and making network calls to verify secrets — this is slow
- GitHub Secret Scanning with Push Protection provides equivalent coverage natively with zero CI time
- Push Protection catches secrets at `git push` time, giving developers immediate feedback

**Action required:** Ensure Secret Scanning and Push Protection are enabled in repo Settings → Code security and analysis.

## Checklist

### Code Quality

- [x] I have reviewed my own code (self-review), including the screen- and snapshots
- [x] I have reviewed my changes locally with an AI assistant (e.g. GitHub Copilot, Kiro, etc.)
- [x] No hardcoded values, magic numbers, or debug code left in

### Validation

- [x] I have added/updated tests that cover my changes
- [x] I have tested across all relevant frameworks (React, Angular, Vue) if applicable

### General

- [x] The PR title follows the conventional commits format (e.g. `feat:`, `fix:`, `chore:`), as in [Git Commit Conventions](docs/conventions.md#git-commits-conventions)
- [ ] If architecture, structure, or conventions changed inside a `packages/*` folder, the corresponding `AGENTS.md` has been updated
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/ci-replace-trufflehog-with-secret-scanning>

<!-- DBUX-TEST-URL-END -->