### PR TITLE
fix(db-puls): transition logical inline-size/block-size instead of width/height

### DIFF
--- a/.changeset/db-puls-logical-transition.md
+++ b/.changeset/db-puls-logical-transition.md
@@ -2,4 +2,4 @@
 "@db-ux/core-components": patch
 ---
 
-Fix the DB Puls animation to transition the logical `inline-size`/`block-size` properties instead of the physical `width`/`height`, matching the properties the puls actually sets. This keeps the animation consistent in logical-property/writing-mode contexts without changing the visual result.
+fix: transition logical inline-size/block-size instead of physical width/height in DB Puls animation

--- a/.changeset/db-puls-logical-transition.md
+++ b/.changeset/db-puls-logical-transition.md
@@ -1,0 +1,5 @@
+---
+"@db-ux/core-components": patch
+---
+
+Fix the DB Puls animation to transition the logical `inline-size`/`block-size` properties instead of the physical `width`/`height`, matching the properties the puls actually sets. This keeps the animation consistent in logical-property/writing-mode contexts without changing the visual result.

--- a/packages/components/src/styles/internal/_db-puls.scss
+++ b/packages/components/src/styles/internal/_db-puls.scss
@@ -32,9 +32,9 @@
 
 		@media (prefers-reduced-motion: no-preference) {
 			transition:
-				height variables.$db-transition-duration-fast
+				block-size variables.$db-transition-duration-fast
 					variables.$db-transition-timing-emotional,
-				width variables.$db-transition-duration-fast
+				inline-size variables.$db-transition-duration-fast
 					variables.$db-transition-timing-emotional;
 		}
 	}


### PR DESCRIPTION
## Proposed changes

The DB Puls animation (`_db-puls.scss`) sets the indicator size via the logical `inline-size`/`block-size` properties, but its `transition` animated the physical `width`/`height`. This mismatch means the animation doesn't reliably apply in logical-property / writing-mode contexts.

This changes the `%db-puls` transition to animate `inline-size`/`block-size`, matching the properties that are actually set. The static result (position, size, color) is unchanged — verified by diffing the compiled CSS of all puls consumers (`tab-item`, `tabs`, `navigation`): the only difference is this single transition line.

Follow-up: this unblocks the tabs PR (#5747), which can then drop its `!important` override that was working around the physical-property transition.

## Checklist

### Code Quality

- [x] I have reviewed my own code (self-review), including the screen- and snapshots
- [x] I have reviewed my changes locally with an AI assistant (e.g. GitHub Copilot, Kiro, etc.)
- [x] No hardcoded values, magic numbers, or debug code left in

### Validation

- [ ] I have added/updated tests that cover my changes
- [x] I have tested across all relevant frameworks (React, Angular, Vue) if applicable

### General

- [x] The PR title follows the conventional commits format (e.g. `feat:`, `fix:`, `chore:`), as in [Git Commit Conventions](docs/conventions.md#git-commits-conventions)
- [x] If architecture, structure, or conventions changed inside a `packages/*` folder, the corresponding `AGENTS.md` has been updated
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/fix-db-puls-logical-transition>

<!-- DBUX-TEST-URL-END -->