### PR TITLE
chore(gitignore): added new entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ npm-debug.log
 **/build/
 **/dist/
 out/
+pnpm-debug.log
+.pnpm-store
 
 .env
 **/*/.env


### PR DESCRIPTION
## Proposed changes

added two new entries to `.gitignore` related to pnpm that we were missing previously.

**pnpm-debug.log**: Generated when pnpm encounters an error during operations like `install` or `publish`. It contains verbose debug output specific to your local environment and has no value for other contributors.

**.pnpm-store**: This is pnpm's content-addressable package store when configured as a local (project-relative) store. It contains cached package tarballs and hard-linked files that can be large and are machine-specific. It should never be committed. It even already happened that this partly got generated locally, so we should avoid having it commited in general.

Both are local artifacts that vary per machine and would bloat the repository without providing any benefit to the team.

## Checklist

### Code Quality

- [x] I have reviewed my own code (self-review), including the screen- and snapshots
- [x] I have reviewed my changes locally with an AI assistant (e.g. GitHub Copilot, Kiro, etc.)
- [x] No hardcoded values, magic numbers, or debug code left in

### Validation

- [ ] ~I have added/updated tests that cover my changes~
- [ ] ~I have tested across all relevant frameworks (React, Angular, Vue) if applicable~

### General

- [x] The PR title follows the conventional commits format (e.g. `feat:`, `fix:`, `chore:`), as in [Git Commit Conventions](docs/conventions.md#git-commits-conventions)
- [ ] If architecture, structure, or conventions changed inside a `packages/*` folder, the corresponding `AGENTS.md` has been updated
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/chore-gitignore-added-new-entries>

<!-- DBUX-TEST-URL-END -->