### PR TITLE
refactor(dependabot): optimize concurrency groups

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -36,13 +36,6 @@ concurrency:
       github.actor != 'dependabot[bot]' &&
       github.ref != 'refs/heads/main'
     }}
-  queue: >-
-    ${{
-      github.event_name == 'pull_request' &&
-      github.actor == 'dependabot[bot]' &&
-      'max' ||
-      'single'
-    }}
 
 jobs:
   init:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -16,8 +16,8 @@ on:
     types: [published]
   workflow_dispatch:
 
-# We'd like to run the pipeline for Dependabot PRs sequentially, and all other PRs in parallel, but still only one action run for each PR.
-# TODO: We won't need this anymore as soon as we get Merge Groups and could remove the concurrency again, which currently brings us pain regarding unstarted, non-self-healing dependabot pipelines
+# We'd like to run the queue for Dependabot PRs sequentially, and all other PRs in parallel, but still only one action run for each PR.
+# TODO: We won't need this anymore as soon as we get Merge Groups and could remove the concurrency again (if those two work well together).
 # NOTE: Concurrency is disabled for release events as they should always run to completion
 concurrency:
   # Creates a unique concurrency group identifier for release events using the git reference
@@ -25,6 +25,7 @@ concurrency:
     ${{
       github.event_name == 'release' &&
       format('release-{0}', github.ref) ||
+      github.event_name == 'pull_request' &&
       github.actor == 'dependabot[bot]' &&
       'dependabot' ||
       format('{0}-{1}', github.workflow, github.ref)
@@ -35,7 +36,13 @@ concurrency:
       github.actor != 'dependabot[bot]' &&
       github.ref != 'refs/heads/main'
     }}
-  queue: max
+  queue: >-
+    ${{
+      github.event_name == 'pull_request' &&
+      github.actor == 'dependabot[bot]' &&
+      'max' ||
+      'single'
+    }}
 
 jobs:
   init:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
 
 # We'd like to run the queue for Dependabot PRs sequentially, and all other PRs in parallel, but still only one action run for each PR.
-# TODO: We won't need this anymore as soon as we get Merge Groups and could remove the concurrency again (if those two work well together).
+# TODO: We won't need this anymore as soon as we get Merge Groups and could remove the concurrency again, which currently brings us pain regarding unstarted, non-self-healing dependabot pipelines
 # NOTE: Concurrency is disabled for release events as they should always run to completion
 concurrency:
   # Creates a unique concurrency group identifier for release events using the git reference

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -35,6 +35,7 @@ concurrency:
       github.actor != 'dependabot[bot]' &&
       github.ref != 'refs/heads/main'
     }}
+  queue: max
 
 jobs:
   init:


### PR DESCRIPTION
## Proposed changes

> You can now allow multiple jobs or workflow runs to wait in the same GitHub Actions concurrency group instead of being limited to a single pending run.

> Previously, a concurrency group could have one run in progress and one pending run. If another run entered the group, the pending run was canceled and replaced. Now, you can configure concurrency groups to queue multiple pending runs and process them sequentially, with support for up to 100 queued jobs or workflow runs per concurrency group.

source: https://github.blog/changelog/2026-05-07-github-actions-concurrency-groups-now-allow-larger-queues/

Currently, if two dependabot PRs (one running and one in the queue, running after the first one) fail, none of the other open ones will run without the developer recreating or rebasing them after these two. This leads to unnecessary developer activity to restart those items.
With this change, all items in the queue would automatically run, except for those that have failed or require review and approval.

We need to optimise the condition on the group name by adding github.event_name == 'pull_request' so that unmerged dependabot PR runs are not restricted by already merged dependabot PR runs on main.

## Checklist

### Code Quality

- [x] I have reviewed my own code (self-review), including the screen- and snapshots
- [x] I have reviewed my changes locally with an AI assistant (e.g. GitHub Copilot, Kiro, etc.)
- [x] No hardcoded values, magic numbers, or debug code left in

### Validation

- [ ] ~I have added/updated tests that cover my changes~
- [ ] ~I have tested across all relevant frameworks (React, Angular, Vue) if applicable~

### General

- [x] The PR title follows the conventional commits format (e.g. `feat:`, `fix:`, `chore:`), as in [Git Commit Conventions](docs/conventions.md#git-commits-conventions)
- [ ] If architecture, structure, or conventions changed inside a `packages/*` folder, the corresponding `AGENTS.md` has been updated
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/refactor-dependabot-increase-queue-for-concurrency-groups>

<!-- DBUX-TEST-URL-END -->