### PR TITLE
refactor: remove unused environment.ts and webComponents conditionals

### DIFF
--- a/packages/components/_templates/mitosis/new/showcases/angular-showcase-component.ejs.t
+++ b/packages/components/_templates/mitosis/new/showcases/angular-showcase-component.ejs.t
@@ -8,7 +8,6 @@ import { <%= h.changeCase.pascal(name) %>Showcase } from '@components/components
 	selector: 'app-<%= name %>',
 	template: '<<%= name %>-showcase></<%= name %>-showcase>',
 	imports: environment.webComponents ? [] : [<%= h.changeCase.pascal(name) %>Showcase],
-	standalone: true,
-	schemas: environment.webComponents ? [CUSTOM_ELEMENTS_SCHEMA] : []
+	standalone: true
 })
 export class <%= h.changeCase.pascal(name) %>Component {}

--- a/packages/components/_templates/mitosis/new/showcases/angular-showcase-component.ejs.t
+++ b/packages/components/_templates/mitosis/new/showcases/angular-showcase-component.ejs.t
@@ -3,7 +3,6 @@ to: "<%= showcases ? `../../showcases/angular-showcase/src/app/components/${name
 ---
 import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { <%= h.changeCase.pascal(name) %>Showcase } from '@components/components/<%= name %>/showcase/<%= name %>.showcase';
-import { environment } from '../../environments/environment';
 
 @Component({
 	selector: 'app-<%= name %>',

--- a/packages/components/_templates/mitosis/new/showcases/angular-showcase-component.ejs.t
+++ b/packages/components/_templates/mitosis/new/showcases/angular-showcase-component.ejs.t
@@ -1,7 +1,7 @@
 ---
 to: "<%= showcases ? `../../showcases/angular-showcase/src/app/components/${name}.component.ts` : null %>"
 ---
-import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { Component } from '@angular/core';
 import { <%= h.changeCase.pascal(name) %>Showcase } from '@components/components/<%= name %>/showcase/<%= name %>.showcase';
 
 @Component({

--- a/packages/components/_templates/mitosis/new/showcases/angular-showcase-component.ejs.t
+++ b/packages/components/_templates/mitosis/new/showcases/angular-showcase-component.ejs.t
@@ -7,7 +7,7 @@ import { <%= h.changeCase.pascal(name) %>Showcase } from '@components/components
 @Component({
 	selector: 'app-<%= name %>',
 	template: '<<%= name %>-showcase></<%= name %>-showcase>',
-	imports: environment.webComponents ? [] : [<%= h.changeCase.pascal(name) %>Showcase],
+	imports: [<%= h.changeCase.pascal(name) %>Showcase],
 	standalone: true
 })
 export class <%= h.changeCase.pascal(name) %>Component {}

--- a/showcases/angular-showcase/src/app/app.component.ts
+++ b/showcases/angular-showcase/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, CUSTOM_ELEMENTS_SCHEMA, OnInit } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterOutlet } from '@angular/router';
 import {
@@ -18,7 +18,6 @@ import {
 	NavigationDirective,
 	SecondaryActionDirective
 } from '@components';
-import { environment } from '../environments/environment';
 import { NavItemComponent } from './nav-item/nav-item.component';
 import {
 	getSortedNavigationItems,
@@ -29,37 +28,23 @@ import {
 @Component({
 	selector: 'app-root',
 	standalone: true,
-	schemas: environment.webComponents ? [CUSTOM_ELEMENTS_SCHEMA] : [],
-	imports: environment.webComponents
-		? [
-				FormsModule,
-				RouterOutlet,
-				NavItemComponent,
-				DBPage,
-				DBHeader,
-				DBNavigation,
-				SecondaryActionDirective,
-				NavigationDirective,
-				MetaNavigationDirective
-			]
-		: [
-				FormsModule,
-				RouterOutlet,
-				NavItemComponent,
-				DBPage,
-				DBHeader,
-				DBBrand,
-				DBNavigation,
-				DBSelect,
-				DBButton,
-				SecondaryActionDirective,
-				NavigationDirective,
-				MetaNavigationDirective
-			],
+	imports: [
+		FormsModule,
+		RouterOutlet,
+		NavItemComponent,
+		DBPage,
+		DBHeader,
+		DBBrand,
+		DBNavigation,
+		DBSelect,
+		DBButton,
+		SecondaryActionDirective,
+		NavigationDirective,
+		MetaNavigationDirective
+	],
 	templateUrl: './app.component.html'
 })
 export class AppComponent implements OnInit {
-	isWebComponents = environment.webComponents;
 	drawerOpen = false;
 	navigationItems: NavItem[] = getSortedNavigationItems(NAVIGATION_ITEMS);
 

--- a/showcases/angular-showcase/src/app/components/form/checkboxes/checkboxes.component.ts
+++ b/showcases/angular-showcase/src/app/components/form/checkboxes/checkboxes.component.ts
@@ -1,17 +1,13 @@
-import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { DBCheckbox } from '@components';
-import { environment } from '../../../../environments/environment';
 import { WrapperComponent } from '../wrapper/wrapper.component';
 
 @Component({
 	selector: 'app-checkboxes',
 	standalone: true,
-	imports: environment.webComponents
-		? [WrapperComponent, FormsModule, ReactiveFormsModule]
-		: [WrapperComponent, DBCheckbox, FormsModule, ReactiveFormsModule],
-	templateUrl: './checkboxes.component.html',
-	schemas: environment.webComponents ? [CUSTOM_ELEMENTS_SCHEMA] : []
+	imports: [WrapperComponent, DBCheckbox, FormsModule, ReactiveFormsModule],
+	templateUrl: './checkboxes.component.html'
 })
 export class CheckboxesComponent {
 	plain = true;

--- a/showcases/angular-showcase/src/app/components/form/custom-selects/custom-selects.component.ts
+++ b/showcases/angular-showcase/src/app/components/form/custom-selects/custom-selects.component.ts
@@ -1,17 +1,18 @@
-import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { DBCustomSelect } from '@components';
-import { environment } from '../../../../environments/environment';
 import { WrapperComponent } from '../wrapper/wrapper.component';
 
 @Component({
 	selector: 'app-custom-selects',
 	standalone: true,
-	imports: environment.webComponents
-		? [WrapperComponent, FormsModule, ReactiveFormsModule]
-		: [WrapperComponent, DBCustomSelect, FormsModule, ReactiveFormsModule],
-	templateUrl: './custom-selects.component.html',
-	schemas: environment.webComponents ? [CUSTOM_ELEMENTS_SCHEMA] : []
+	imports: [
+		WrapperComponent,
+		DBCustomSelect,
+		FormsModule,
+		ReactiveFormsModule
+	],
+	templateUrl: './custom-selects.component.html'
 })
 export class CustomSelectsComponent {
 	plain = ['combobox-2'];

--- a/showcases/angular-showcase/src/app/components/form/form.component.ts
+++ b/showcases/angular-showcase/src/app/components/form/form.component.ts
@@ -1,9 +1,4 @@
-import {
-	Component,
-	CUSTOM_ELEMENTS_SCHEMA,
-	NO_ERRORS_SCHEMA,
-	signal
-} from '@angular/core';
+import { Component, NO_ERRORS_SCHEMA, signal } from '@angular/core';
 import {
 	FormControl,
 	FormGroup,
@@ -25,32 +20,29 @@ import {
 	DBTag,
 	DBTextarea
 } from '@components';
-import { environment } from '../../../environments/environment';
 
 @Component({
 	selector: 'app-form',
 	templateUrl: './form.component.html',
-	imports: environment.webComponents
-		? [FormsModule, ReactiveFormsModule]
-		: [
-				FormsModule,
-				ReactiveFormsModule,
-				DBInput,
-				DBTextarea,
-				DBSelect,
-				DBRadio,
-				DBTag,
-				DBCheckbox,
-				DBDivider,
-				DBButton,
-				DBTabs,
-				DBTabList,
-				DBTabItem,
-				DBTabPanel,
-				DBSwitch
-			],
+	imports: [
+		FormsModule,
+		ReactiveFormsModule,
+		DBInput,
+		DBTextarea,
+		DBSelect,
+		DBRadio,
+		DBTag,
+		DBCheckbox,
+		DBDivider,
+		DBButton,
+		DBTabs,
+		DBTabList,
+		DBTabItem,
+		DBTabPanel,
+		DBSwitch
+	],
 	standalone: true,
-	schemas: [NO_ERRORS_SCHEMA, CUSTOM_ELEMENTS_SCHEMA]
+	schemas: [NO_ERRORS_SCHEMA]
 })
 export class FormComponent {
 	// DB Switch with Angular signals

--- a/showcases/angular-showcase/src/app/components/form/inputs/inputs.component.ts
+++ b/showcases/angular-showcase/src/app/components/form/inputs/inputs.component.ts
@@ -1,17 +1,13 @@
-import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { DBInput } from '@components';
-import { environment } from '../../../../environments/environment';
 import { WrapperComponent } from '../wrapper/wrapper.component';
 
 @Component({
 	selector: 'app-inputs',
 	standalone: true,
-	imports: environment.webComponents
-		? [WrapperComponent, FormsModule, ReactiveFormsModule]
-		: [WrapperComponent, DBInput, FormsModule, ReactiveFormsModule],
-	templateUrl: './inputs.component.html',
-	schemas: environment.webComponents ? [CUSTOM_ELEMENTS_SCHEMA] : []
+	imports: [WrapperComponent, DBInput, FormsModule, ReactiveFormsModule],
+	templateUrl: './inputs.component.html'
 })
 export class InputsComponent {
 	plain = 'test1';

--- a/showcases/angular-showcase/src/app/components/form/radios/radios.component.ts
+++ b/showcases/angular-showcase/src/app/components/form/radios/radios.component.ts
@@ -1,19 +1,13 @@
-import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { DBRadio } from '@components';
-import { environment } from '../../../../environments/environment';
 import { WrapperComponent } from '../wrapper/wrapper.component';
 
 @Component({
 	selector: 'app-radios',
 	standalone: true,
-	imports: [
-		environment.webComponents
-			? [WrapperComponent, FormsModule, ReactiveFormsModule]
-			: [WrapperComponent, DBRadio, FormsModule, ReactiveFormsModule]
-	],
-	templateUrl: './radios.component.html',
-	schemas: environment.webComponents ? [CUSTOM_ELEMENTS_SCHEMA] : []
+	imports: [WrapperComponent, DBRadio, FormsModule, ReactiveFormsModule],
+	templateUrl: './radios.component.html'
 })
 export class RadiosComponent {
 	plain = '';

--- a/showcases/angular-showcase/src/app/components/form/selects/selects.component.ts
+++ b/showcases/angular-showcase/src/app/components/form/selects/selects.component.ts
@@ -1,17 +1,13 @@
-import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { DBSelect } from '@components';
-import { environment } from '../../../../environments/environment';
 import { WrapperComponent } from '../wrapper/wrapper.component';
 
 @Component({
 	selector: 'app-selects',
 	standalone: true,
-	imports: environment.webComponents
-		? [WrapperComponent, FormsModule, ReactiveFormsModule]
-		: [WrapperComponent, DBSelect, FormsModule, ReactiveFormsModule],
-	templateUrl: './selects.component.html',
-	schemas: environment.webComponents ? [CUSTOM_ELEMENTS_SCHEMA] : []
+	imports: [WrapperComponent, DBSelect, FormsModule, ReactiveFormsModule],
+	templateUrl: './selects.component.html'
 })
 export class SelectsComponent {
 	plain = 'combobox-2';

--- a/showcases/angular-showcase/src/app/components/form/switches/switches.component.ts
+++ b/showcases/angular-showcase/src/app/components/form/switches/switches.component.ts
@@ -1,17 +1,13 @@
-import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { DBSwitch } from '@components';
-import { environment } from '../../../../environments/environment';
 import { WrapperComponent } from '../wrapper/wrapper.component';
 
 @Component({
 	selector: 'app-switches',
 	standalone: true,
-	imports: environment.webComponents
-		? [WrapperComponent, FormsModule, ReactiveFormsModule]
-		: [WrapperComponent, DBSwitch, FormsModule, ReactiveFormsModule],
-	templateUrl: './switches.component.html',
-	schemas: environment.webComponents ? [CUSTOM_ELEMENTS_SCHEMA] : []
+	imports: [WrapperComponent, DBSwitch, FormsModule, ReactiveFormsModule],
+	templateUrl: './switches.component.html'
 })
 export class SwitchesComponent {
 	plain = true;

--- a/showcases/angular-showcase/src/app/components/form/textareas/textareas.component.ts
+++ b/showcases/angular-showcase/src/app/components/form/textareas/textareas.component.ts
@@ -1,17 +1,13 @@
-import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { DBTextarea } from '@components';
-import { environment } from '../../../../environments/environment';
 import { WrapperComponent } from '../wrapper/wrapper.component';
 
 @Component({
 	selector: 'app-textareas',
 	standalone: true,
-	imports: environment.webComponents
-		? [WrapperComponent, FormsModule, ReactiveFormsModule]
-		: [WrapperComponent, DBTextarea, FormsModule, ReactiveFormsModule],
-	templateUrl: './textareas.component.html',
-	schemas: environment.webComponents ? [CUSTOM_ELEMENTS_SCHEMA] : []
+	imports: [WrapperComponent, DBTextarea, FormsModule, ReactiveFormsModule],
+	templateUrl: './textareas.component.html'
 })
 export class TextareasComponent {
 	plain = 'test1';

--- a/showcases/angular-showcase/src/app/components/home/home.component.ts
+++ b/showcases/angular-showcase/src/app/components/home/home.component.ts
@@ -1,6 +1,5 @@
-import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { Component } from '@angular/core';
 import { DBTabItem, DBTabList, DBTabPanel, DBTabs } from '@components';
-import { environment } from '../../../environments/environment';
 import { CheckboxesComponent } from '../form/checkboxes/checkboxes.component';
 import { CustomSelectsComponent } from '../form/custom-selects/custom-selects.component';
 import { FormComponent } from '../form/form.component';
@@ -23,10 +22,10 @@ import { TextareasComponent } from '../form/textareas/textareas.component';
 		RadiosComponent,
 		CustomSelectsComponent,
 		SwitchesComponent,
-		...(environment.webComponents
-			? []
-			: [DBTabs, DBTabItem, DBTabList, DBTabPanel])
-	],
-	schemas: environment.webComponents ? [CUSTOM_ELEMENTS_SCHEMA] : []
+		DBTabs,
+		DBTabItem,
+		DBTabList,
+		DBTabPanel
+	]
 })
 export class HomeComponent {}

--- a/showcases/angular-showcase/src/app/components/table.component.ts
+++ b/showcases/angular-showcase/src/app/components/table.component.ts
@@ -1,12 +1,10 @@
-import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { Component } from '@angular/core';
 import { TableShowcase } from '@components/components/table/showcase/table.showcase';
-import { environment } from '../../environments/environment';
 
 @Component({
 	selector: 'app-table',
 	template: '<table-showcase></table-showcase>',
-	imports: environment.webComponents ? [] : [TableShowcase],
-	standalone: true,
-	schemas: environment.webComponents ? [CUSTOM_ELEMENTS_SCHEMA] : []
+	imports: [TableShowcase],
+	standalone: true
 })
 export class TableComponent {}

--- a/showcases/angular-showcase/src/app/nav-item/nav-item.component.ts
+++ b/showcases/angular-showcase/src/app/nav-item/nav-item.component.ts
@@ -1,7 +1,6 @@
-import { Component, CUSTOM_ELEMENTS_SCHEMA, Input } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 import { DBNavigationItem, NavigationContentDirective } from '@components';
-import { environment } from '../../environments/environment';
 import { NavItem } from '../utils/navigation-item';
 
 @Component({
@@ -13,7 +12,6 @@ import { NavItem } from '../utils/navigation-item';
 		DBNavigationItem,
 		NavigationContentDirective
 	],
-	schemas: environment.webComponents ? [CUSTOM_ELEMENTS_SCHEMA] : [],
 	standalone: true
 })
 export class NavItemComponent {

--- a/showcases/angular-showcase/src/environments/environment.ts
+++ b/showcases/angular-showcase/src/environments/environment.ts
@@ -1,3 +1,0 @@
-export const environment = {
-	webComponents: false
-};


### PR DESCRIPTION
## Proposed changes

Removes the `showcases/angular-showcase/src/environments/environment.ts` file and all `environment.webComponents` ternary expressions across 11 component files in the angular showcase.

The `webComponents` flag was always set to `false`, making all the conditional branches dead code. This simplifies the component decorators by keeping only the non-webComponents code paths and removes unused `CUSTOM_ELEMENTS_SCHEMA` imports.

## Checklist

### Code Quality

- [x] I have reviewed my own code (self-review), including the screen- and snapshots
- [x] I have reviewed my changes locally with an AI assistant (e.g. GitHub Copilot, Kiro, etc.)
- [x] No hardcoded values, magic numbers, or debug code left in

### Validation

- [ ] I have added/updated tests that cover my changes
- [x] I have tested across all relevant frameworks (React, Angular, Vue) if applicable

### General

- [x] The PR title follows the conventional commits format (e.g. `feat:`, `fix:`, `chore:`), as in [Git Commit Conventions](docs/conventions.md#git-commits-conventions)
- [x] If architecture, structure, or conventions changed inside a `packages/*` folder, the corresponding `AGENTS.md` has been updated
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/refactor-remove-angular-environment>

<!-- DBUX-TEST-URL-END -->