### PR TITLE
fix: "fix tooltip listener cleanup" review

### DIFF
--- a/packages/components/src/components/tooltip/model.ts
+++ b/packages/components/src/components/tooltip/model.ts
@@ -40,6 +40,8 @@ export type DBTooltipProps = DBTooltipDefaultProps &
 export type DBTooltipDefaultState = {
 	getParent: () => HTMLElement;
 	_attachedParent?: HTMLElement;
+	_attachedAttribute?: string;
+	_previousAttributeValue?: string;
 	_boundListeners?: {
 		parent: HTMLElement;
 		type: string;

--- a/packages/components/src/components/tooltip/tooltip.lite.tsx
+++ b/packages/components/src/components/tooltip/tooltip.lite.tsx
@@ -32,6 +32,8 @@ export default function DBTooltip(props: DBTooltipProps) {
 		_documentScrollListenerCallbackId: undefined,
 		_observer: undefined,
 		_attachedParent: undefined,
+		_attachedAttribute: undefined,
+		_previousAttributeValue: undefined,
 		_boundListeners: [],
 		handleClick: (event: ClickEvent<HTMLElement>) => {
 			event.stopPropagation();
@@ -121,20 +123,34 @@ export default function DBTooltip(props: DBTooltipProps) {
 			});
 			state._boundListeners = [];
 
-			// Remove attributes this tooltip set on its parent, but only while
-			// they still belong to this tooltip (avoid clobbering another one).
+			// Restore attributes this tooltip set on its parent. Only restore
+			// while the current value still matches what this tooltip wrote,
+			// to avoid clobbering a value set by another tooltip afterwards.
 			const parent = state._attachedParent;
 			if (parent) {
 				if (parent.dataset['hasTooltip'] === 'true') {
 					delete parent.dataset['hasTooltip'];
 				}
-				if (parent.getAttribute('aria-labelledby') === state._id) {
-					parent.removeAttribute('aria-labelledby');
+
+				const attribute = state._attachedAttribute;
+				if (attribute && parent.getAttribute(attribute) === state._id) {
+					// If the trigger declaratively supplied the same value
+					// itself (e.g. aria-describedby="tooltip-01"), restore it
+					// instead of removing it. The framework won't reapply an
+					// unchanged prop after the child cleanup.
+					if (state._previousAttributeValue !== undefined) {
+						parent.setAttribute(
+							attribute,
+							state._previousAttributeValue
+						);
+					} else {
+						parent.removeAttribute(attribute);
+					}
 				}
-				if (parent.getAttribute('aria-describedby') === state._id) {
-					parent.removeAttribute('aria-describedby');
-				}
+
 				state._attachedParent = undefined;
+				state._attachedAttribute = undefined;
+				state._previousAttributeValue = undefined;
 			}
 		}
 	});
@@ -178,11 +194,18 @@ export default function DBTooltip(props: DBTooltipProps) {
 
 				parent.dataset['hasTooltip'] = 'true';
 
-				if (props.variant === 'label') {
-					parent.setAttribute('aria-labelledby', state._id);
-				} else {
-					parent.setAttribute('aria-describedby', state._id);
-				}
+				const attribute =
+					props.variant === 'label'
+						? 'aria-labelledby'
+						: 'aria-describedby';
+
+				// Capture the value the parent had before this tooltip writes
+				// to it, so we can restore it on cleanup instead of wrongly
+				// removing a value the trigger supplied declaratively.
+				state._previousAttributeValue =
+					parent.getAttribute(attribute) ?? undefined;
+				state._attachedAttribute = attribute;
+				parent.setAttribute(attribute, state._id);
 
 				state._attachedParent = parent;
 			}


### PR DESCRIPTION
## Proposed changes

The original cleanup inferred ownership by checking `parent.getAttribute('aria-describedby') === state._id`. The problem: when a trigger declaratively sets `aria-describedby="tooltip-01"` itself (the documented React usage), and the tooltip uses that same id, the equality check passes and the attribute gets removed. Since the parent prop never changed, React won't reapply it after the child unmounts, so the trigger silently loses its accessible name/description.

The new approach captures the parent's attribute value before the tooltip writes to it:

- On attach, `_previousAttributeValue` records what was already there (the trigger's declarative value, or `undefined` if none) and `_attachedAttribute` records which attribute (`aria-labelledby` vs `aria-describedby`).
- On cleanup, if the current value still matches what this tooltip wrote, it restores `_previousAttributeValue` when one existed, otherwise removes the attribute. The id-equality guard is retained so a value set by a different tooltip afterward isn't clobbered.

## Checklist

### Code Quality

- [x] I have reviewed my own code (self-review), including the screen- and snapshots
- [ ] I have reviewed my changes locally with an AI assistant (e.g. GitHub Copilot, Kiro, etc.)
- [x] No hardcoded values, magic numbers, or debug code left in

### Validation

- [ ] ~I have added/updated tests that cover my changes~
- [ ] ~I have tested across all relevant frameworks (React, Angular, Vue) if applicable~

### General

- [x] The PR title follows the conventional commits format (e.g. `feat:`, `fix:`, `chore:`), as in [Git Commit Conventions](docs/conventions.md#git-commits-conventions)
- [ ] If architecture, structure, or conventions changed inside a `packages/*` folder, the corresponding `AGENTS.md` has been updated
