### PR TITLE
refactor: remove obsolete script

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "prepare": "husky",
     "regenerate:screenshots": "pnpm run build && pnpm --filter react-showcase run build && pnpm --filter react-showcase run regenerate:visual-snapshots && pnpm --filter react-showcase run regenerate:aria-snapshots",
     "release:publish": "node scripts/github/publish-npm.js",
-    "reset": "pnpm run clean && pnpm install && pnpm run prepare",
     "rm:builds": "pnpm --filter scripts run rm:builds",
     "start": "pnpm --filter patternhub run start",
     "test": "pnpm --filter scripts run test",


### PR DESCRIPTION
## Proposed changes

As a followup to https://github.com/db-ux-design-system/core-web/pull/7137 we could remove this script as well. The `pnpm` lifecycle script `prepare` is being executed by `pnpm` version >= 11 again, so we don't need to provide this additional script anymore (`pnpm i` alone doesn't provide any benefit anymore for an additional script).

## Checklist

### Code Quality

- [x] I have reviewed my own code (self-review), including the screen- and snapshots
- [x] I have reviewed my changes locally with an AI assistant (e.g. GitHub Copilot, Kiro, etc.)
- [x] No hardcoded values, magic numbers, or debug code left in

### Validation

- [ ] ~I have added/updated tests that cover my changes~
- [ ] ~I have tested across all relevant frameworks (React, Angular, Vue) if applicable~

### General

- [x] The PR title follows the conventional commits format (e.g. `feat:`, `fix:`, `chore:`), as in [Git Commit Conventions](docs/conventions.md#git-commits-conventions)
- [ ] If architecture, structure, or conventions changed inside a `packages/*` folder, the corresponding `AGENTS.md` has been updated
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/refactor-remove-obsolete-script>

<!-- DBUX-TEST-URL-END -->