### PR TITLE
fix(storybook): local build

### DIFF
--- a/storybooks/vue-storybook/package.json
+++ b/storybooks/vue-storybook/package.json
@@ -10,7 +10,7 @@
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
-    "build": "storybook build --output-dir ../../build-storybooks/vue-storybook",
+    "build": "cross-env NODE_OPTIONS=--max-old-space-size=8192 storybook build --output-dir ../../build-storybooks/vue-storybook",
     "storybook": "cross-env NODE_OPTIONS=--max-old-space-size=8192 storybook dev -p 6007"
   },
   "dependencies": {


### PR DESCRIPTION
## Proposed changes

The Vue Storybook `build` script was running without any memory limit increase, while the `storybook dev` script already had `--max-old-space-size=8192`. With Storybook 10 + Rolldown bundling all Vue components at once, the build exceeds Node's default ~4 GB heap limit. Adding `cross-env NODE_OPTIONS=--max-old-space-size=8192` gives it 8 GB to work with.

## Checklist

### Code Quality

- [x] I have reviewed my own code (self-review), including the screen- and snapshots
- [x] I have reviewed my changes locally with an AI assistant (e.g. GitHub Copilot, Kiro, etc.)
- [x] No hardcoded values, magic numbers, or debug code left in

### Validation

- [ ] ~I have added/updated tests that cover my changes~
- [ ] ~I have tested across all relevant frameworks (React, Angular, Vue) if applicable~

### General

- [x] The PR title follows the conventional commits format (e.g. `feat:`, `fix:`, `chore:`), as in [Git Commit Conventions](docs/conventions.md#git-commits-conventions)
- [ ] If architecture, structure, or conventions changed inside a `packages/*` folder, the corresponding `AGENTS.md` has been updated
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/fix-storybook-local-build>

<!-- DBUX-TEST-URL-END -->