### PR TITLE
fix(localhost): warning after start

### DIFF
--- a/showcases/patternhub/pages/404.tsx
+++ b/showcases/patternhub/pages/404.tsx
@@ -5,7 +5,11 @@ const FallbackPage = () => {
 	const { push, asPath } = useRouter();
 
 	useEffect(() => {
-		void push(asPath.endsWith('/overview') ? '/' : `${asPath}/overview`);
+		if (asPath === '/' || asPath.endsWith('/overview')) {
+			void push('/');
+		} else {
+			void push(`${asPath}/overview`);
+		}
 	}, []);
 	return null;
 };


### PR DESCRIPTION
## Proposed changes

On localhost you just need to access the app at the right URL. Elsewhere you'll get a 404 and an immediate redirect. From the users perspective this is fine, but on the terminal there's a warning:

<img width="681" height="269" alt="image" src="https://github.com/user-attachments/assets/5fe2b330-56ed-4c19-800e-2b70afb16f11" />

When you run `pnpm run start`, the script sets `NEXT_PUBLIC_BASE_PATH=/core-web/sub`, which configures Next.js's `basePath` to `/core-web/sub`. That means all routes are served under that prefix:

- **Correct URL:** `http://localhost:3000/core-web/sub`
- Hitting `http://localhost:3000/` directly gives a 404 because nothing is served at the root when a basePath is configured.

The `//overview` error in the console is a bug in `404.tsx` — when `asPath` is `/`, the redirect expression `${asPath}/overview` produces `//overview` (double slash). But that only triggers when you hit a route outside the basePath. I've fixed it to redirect to `/` when already at the root instead of generating an invalid path.

## Checklist

### Code Quality

- [x] I have reviewed my own code (self-review), including the screen- and snapshots
- [ ] I have reviewed my changes locally with an AI assistant (e.g. GitHub Copilot, Kiro, etc.)
- [x] No hardcoded values, magic numbers, or debug code left in

### Validation

- [ ] ~I have added/updated tests that cover my changes~
- [ ] ~I have tested across all relevant frameworks (React, Angular, Vue) if applicable~

### General

- [x] The PR title follows the conventional commits format (e.g. `feat:`, `fix:`, `chore:`), as in [Git Commit Conventions](docs/conventions.md#git-commits-conventions)
- [ ] If architecture, structure, or conventions changed inside a `packages/*` folder, the corresponding `AGENTS.md` has been updated
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/fix-localhost-warning>

<!-- DBUX-TEST-URL-END -->