### PR TITLE
fix: pipeline for forks

### DIFF
--- a/.github/workflows/00-init.yml
+++ b/.github/workflows/00-init.yml
@@ -33,7 +33,7 @@ on:
         description: "If this is a changeset release PR"
         value: ${{ jobs.init.outputs.isChangesetRelease }}
       isFork:
-        description: "If this is a pull request from a fork"
+        description: "If this is a pull request from a fork or running in a fork repository"
         value: ${{ jobs.init.outputs.isFork }}
       # Publish outputs
       release:
@@ -118,11 +118,18 @@ jobs:
             echo "isChangesetRelease=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: 🍴 Check if fork PR
+      - name: 🍴 Check if fork PR or fork repository
         id: fork-check
         run: |
+          # Case 1: Pull request from a fork — the head repo differs from the base repo.
+          # This is the most common fork scenario and does not require a hardcoded org name.
           if [[ "${{ github.event_name }}" == "pull_request" ]] && \
              [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+            echo "isFork=true" >> $GITHUB_OUTPUT
+          # Case 2: Non-PR events (push, workflow_dispatch) running inside a fork repository.
+          # The PR head repo check above is empty for these events, so we fall back to an
+          # owner check to prevent jobs that require upstream secrets (e.g. Figma) from running.
+          elif [[ "${{ github.repository_owner }}" != "db-ux-design-system" ]]; then
             echo "isFork=true" >> $GITHUB_OUTPUT
           else
             echo "isFork=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/00-init.yml
+++ b/.github/workflows/00-init.yml
@@ -32,6 +32,9 @@ on:
       isChangesetRelease:
         description: "If this is a changeset release PR"
         value: ${{ jobs.init.outputs.isChangesetRelease }}
+      isFork:
+        description: "If this is a pull request from a fork"
+        value: ${{ jobs.init.outputs.isFork }}
       # Publish outputs
       release:
         description: "If the current tag is a release"
@@ -53,6 +56,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       test-ally: ${{ steps.ally.outputs.test-ally }}
       isChangesetRelease: ${{ steps.changeset-check.outputs.isChangesetRelease }}
+      isFork: ${{ steps.fork-check.outputs.isFork }}
     runs-on: ubuntu-24.04 # Use Ubuntu 24.04 explicitly
     steps:
       - name: ⏬ Checkout repo
@@ -112,6 +116,16 @@ jobs:
             echo "isChangesetRelease=true" >> $GITHUB_OUTPUT
           else
             echo "isChangesetRelease=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: 🍴 Check if fork PR
+        id: fork-check
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]] && \
+             [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+            echo "isFork=true" >> $GITHUB_OUTPUT
+          else
+            echo "isFork=false" >> $GITHUB_OUTPUT
           fi
 
   publish:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -68,7 +68,7 @@ jobs:
     needs: [build-packages]
 
   build-figma-code-connect:
-    if: ${{ github.event_name != 'release' && github.repository_owner == 'db-ux-design-system' && needs.init.outputs.isChangesetRelease != 'true' }}
+    if: ${{ github.event_name != 'release' && github.repository_owner == 'db-ux-design-system' && needs.init.outputs.isChangesetRelease != 'true' && needs.init.outputs.isFork != 'true' }}
     uses: ./.github/workflows/01-build-figma-code-connect.yml
     needs: [init]
 
@@ -115,7 +115,7 @@ jobs:
     secrets: inherit
 
   test-figma-code-connect:
-    if: ${{ github.event_name != 'release' && github.repository_owner == 'db-ux-design-system' && needs.init.outputs.isChangesetRelease != 'true' }}
+    if: ${{ github.event_name != 'release' && github.repository_owner == 'db-ux-design-system' && needs.init.outputs.isChangesetRelease != 'true' && needs.init.outputs.isFork != 'true' }}
     uses: ./.github/workflows/02-test-figma-code-connect.yml
     needs: [build-figma-code-connect, init]
     secrets: inherit
@@ -175,6 +175,7 @@ jobs:
     secrets: inherit
 
   build-showcase-stencil:
+    if: ${{ needs.init.outputs.isFork != 'true' }}
     uses: ./.github/workflows/01-build-showcases.yml
     needs: [build-packages, init]
     secrets: inherit
@@ -188,6 +189,7 @@ jobs:
     needs: [build-showcase-stencil]
 
   build-showcase-angular:
+    if: ${{ needs.init.outputs.isFork != 'true' }}
     uses: ./.github/workflows/01-build-showcases.yml
     needs: [build-packages]
     secrets: inherit
@@ -201,6 +203,7 @@ jobs:
     needs: [build-showcase-angular]
 
   build-showcase-angular-ssr:
+    if: ${{ needs.init.outputs.isFork != 'true' }}
     uses: ./.github/workflows/01-build-showcases.yml
     needs: [build-packages]
     secrets: inherit
@@ -214,6 +217,7 @@ jobs:
     needs: [build-showcase-angular-ssr]
 
   build-showcase-react:
+    if: ${{ needs.init.outputs.isFork != 'true' }}
     uses: ./.github/workflows/01-build-showcases.yml
     needs: [build-packages]
     secrets: inherit
@@ -227,6 +231,7 @@ jobs:
     needs: [build-showcase-react]
 
   build-showcase-next:
+    if: ${{ needs.init.outputs.isFork != 'true' }}
     uses: ./.github/workflows/01-build-showcases.yml
     needs: [build-packages]
     secrets: inherit
@@ -240,6 +245,7 @@ jobs:
     needs: [build-showcase-next]
 
   build-showcase-vue:
+    if: ${{ needs.init.outputs.isFork != 'true' }}
     uses: ./.github/workflows/01-build-showcases.yml
     needs: [build-packages]
     secrets: inherit
@@ -253,6 +259,7 @@ jobs:
     needs: [build-showcase-vue]
 
   build-showcase-nuxt:
+    if: ${{ needs.init.outputs.isFork != 'true' }}
     uses: ./.github/workflows/01-build-showcases.yml
     needs: [build-packages]
     secrets: inherit

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -555,7 +555,7 @@ jobs:
   publish-figma-code-connect:
     if: ${{ !cancelled() && github.actor != 'dependabot[bot]' && github.event_name != 'release' && needs.init.outputs.isFork != 'true' && github.ref == 'refs/heads/main' && needs.checks-done.result == 'success' }}
     uses: ./.github/workflows/03-publish-figma-code-connect.yml
-    needs: [checks-done, test-figma-code-connect]
+    needs: [checks-done, test-figma-code-connect, init]
     secrets: inherit
 
   preview-url-pr-description:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -175,7 +175,6 @@ jobs:
     secrets: inherit
 
   build-showcase-stencil:
-    if: ${{ needs.init.outputs.isFork != 'true' }}
     uses: ./.github/workflows/01-build-showcases.yml
     needs: [build-packages, init]
     secrets: inherit
@@ -189,7 +188,6 @@ jobs:
     needs: [build-showcase-stencil]
 
   build-showcase-angular:
-    if: ${{ needs.init.outputs.isFork != 'true' }}
     uses: ./.github/workflows/01-build-showcases.yml
     needs: [build-packages]
     secrets: inherit
@@ -203,7 +201,6 @@ jobs:
     needs: [build-showcase-angular]
 
   build-showcase-angular-ssr:
-    if: ${{ needs.init.outputs.isFork != 'true' }}
     uses: ./.github/workflows/01-build-showcases.yml
     needs: [build-packages]
     secrets: inherit
@@ -217,7 +214,6 @@ jobs:
     needs: [build-showcase-angular-ssr]
 
   build-showcase-react:
-    if: ${{ needs.init.outputs.isFork != 'true' }}
     uses: ./.github/workflows/01-build-showcases.yml
     needs: [build-packages]
     secrets: inherit
@@ -231,7 +227,6 @@ jobs:
     needs: [build-showcase-react]
 
   build-showcase-next:
-    if: ${{ needs.init.outputs.isFork != 'true' }}
     uses: ./.github/workflows/01-build-showcases.yml
     needs: [build-packages]
     secrets: inherit
@@ -245,7 +240,6 @@ jobs:
     needs: [build-showcase-next]
 
   build-showcase-vue:
-    if: ${{ needs.init.outputs.isFork != 'true' }}
     uses: ./.github/workflows/01-build-showcases.yml
     needs: [build-packages]
     secrets: inherit
@@ -259,7 +253,6 @@ jobs:
     needs: [build-showcase-vue]
 
   build-showcase-nuxt:
-    if: ${{ needs.init.outputs.isFork != 'true' }}
     uses: ./.github/workflows/01-build-showcases.yml
     needs: [build-packages]
     secrets: inherit

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -68,7 +68,7 @@ jobs:
     needs: [build-packages]
 
   build-figma-code-connect:
-    if: ${{ github.event_name != 'release' && github.repository_owner == 'db-ux-design-system' && needs.init.outputs.isChangesetRelease != 'true' && needs.init.outputs.isFork != 'true' }}
+    if: ${{ github.event_name != 'release' && needs.init.outputs.isChangesetRelease != 'true' && needs.init.outputs.isFork != 'true' }}
     uses: ./.github/workflows/01-build-figma-code-connect.yml
     needs: [init]
 
@@ -115,7 +115,7 @@ jobs:
     secrets: inherit
 
   test-figma-code-connect:
-    if: ${{ github.event_name != 'release' && github.repository_owner == 'db-ux-design-system' && needs.init.outputs.isChangesetRelease != 'true' && needs.init.outputs.isFork != 'true' }}
+    if: ${{ github.event_name != 'release' && needs.init.outputs.isChangesetRelease != 'true' && needs.init.outputs.isFork != 'true' }}
     uses: ./.github/workflows/02-test-figma-code-connect.yml
     needs: [build-figma-code-connect, init]
     secrets: inherit
@@ -539,7 +539,7 @@ jobs:
     if: |
       ${{
       !cancelled() && github.actor != 'dependabot[bot]' &&
-      (github.event_name == 'release' || github.event.pull_request == null || github.event.pull_request.head.repo.owner.login == 'db-ux-design-system') &&
+      (github.event_name == 'release' || github.event.pull_request == null || needs.init.outputs.isFork != 'true') &&
       needs.init.outputs.isChangesetRelease != 'true' &&
       needs.checks-done.result == 'success'
       }}
@@ -553,7 +553,7 @@ jobs:
       repoOwner: ${{ needs.init.outputs.repoOwner }}
 
   publish-figma-code-connect:
-    if: ${{ !cancelled() && github.actor != 'dependabot[bot]' && github.event_name != 'release' && github.repository_owner == 'db-ux-design-system' && github.ref == 'refs/heads/main' && needs.checks-done.result == 'success' }}
+    if: ${{ !cancelled() && github.actor != 'dependabot[bot]' && github.event_name != 'release' && needs.init.outputs.isFork != 'true' && github.ref == 'refs/heads/main' && needs.checks-done.result == 'success' }}
     uses: ./.github/workflows/03-publish-figma-code-connect.yml
     needs: [checks-done, test-figma-code-connect]
     secrets: inherit

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -19,5 +19,5 @@ jobs:
     uses: ./.github/workflows/99-dependency-review.yml
 
   labeler:
-    if: github.event.pull_request.head.repo.owner.login == 'db-ux-design-system'
+    if: github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/99-labeler.yml


### PR DESCRIPTION
## Proposed changes

we shouldn't run any Figma related steps for repository forks.

- **`default.yml`**: replaced `github.repository_owner == 'db-ux-design-system'` by `needs.init.outputs.isFork != 'true'`, as `github.repository_owner == 'db-ux-design-system'` would be `true` for a pipeline being run for a PR in the context of our repository (which is the case for all PRs that target our repository):
  - `build-figma-code-connect`
  - `test-figma-code-connect`
  - `publish-figma-code-connect`
  - `deploy`
- **`pull-request.yml`**: uses `github.event.pull_request.head.repo.full_name == github.repository` (same logic as `00-init.yml's` fork-check, just inlined since there's no init job in this workflow).

## Checklist

### Code Quality

- [x] I have reviewed my own code (self-review), including the screen- and snapshots
- [ ] I have reviewed my changes locally with an AI assistant (e.g. GitHub Copilot, Kiro, etc.)
- [x] No hardcoded values, magic numbers, or debug code left in

### Validation

- [ ] ~I have added/updated tests that cover my changes~
- [ ] ~I have tested across all relevant frameworks (React, Angular, Vue) if applicable~

### General

- [x] The PR title follows the conventional commits format (e.g. `feat:`, `fix:`, `chore:`), as in [Git Commit Conventions](docs/conventions.md#git-commits-conventions)
- [ ] If architecture, structure, or conventions changed inside a `packages/*` folder, the corresponding `AGENTS.md` has been updated
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/fix-pipeline-for-forks>

<!-- DBUX-TEST-URL-END -->