### PR TITLE
fix(DBInput): renders values in placeholder style when value prop is …

### DIFF
--- a/packages/components/src/styles/internal/_form-components.scss
+++ b/packages/components/src/styles/internal/_form-components.scss
@@ -92,7 +92,8 @@ $db-min-inline-size: var(
 				[value*="7"],
 				[value*="8"],
 				[value*="9"],
-				[value*="0"]
+				[value*="0"],
+    			:placeholder-shown
 			)::-webkit-datetime-edit {
 			@content;
 		}


### PR DESCRIPTION
## Proposed changes

fix(DBInput): renders values in placeholder style when value prop is not set

## Checklist

### Code Quality

- [x] I have reviewed my own code (self-review), including the screen- and snapshots
- [ ] I have reviewed my changes locally with an AI assistant (e.g. GitHub Copilot, Kiro, etc.)
- [x] No hardcoded values, magic numbers, or debug code left in

### Validation

- [ ] ~I have added/updated tests that cover my changes~
- [ ] ~I have tested across all relevant frameworks (React, Angular, Vue) if applicable~

### General

- [x] The PR title follows the conventional commits format (e.g. `feat:`, `fix:`, `chore:`), as in [Git Commit Conventions](docs/conventions.md#git-commits-conventions)
- [ ] If architecture, structure, or conventions changed inside a `packages/*` folder, the corresponding `AGENTS.md` has been updated
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/6626-dbinput-renders-values-in-placeholder-style-when-value-prop-is-not-set>

<!-- DBUX-TEST-URL-END -->