### PR TITLE
refactor: Set PR draft status to always for release workflow

### DIFF
--- a/.github/workflows/changesets-release-pr.yml
+++ b/.github/workflows/changesets-release-pr.yml
@@ -51,6 +51,7 @@ jobs:
           commit: "chore(release): version packages"
           title: "chore(release): version packages"
           version: pnpm run ci:version
+          prDraft: always
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           HUSKY: 0 # Disable Husky hooks in CI


### PR DESCRIPTION
## Proposed changes

we'd like to keep an Changesets PR in draft, so that it would be an active decision to mark it as "ready for review" and merging it afterwards. This is simply an additional layer of preventing a whoopsie.

## Checklist

### Code Quality

- [x] I have reviewed my own code (self-review), including the screen- and snapshots
- [ ] I have reviewed my changes locally with an AI assistant (e.g. GitHub Copilot, Kiro, etc.)
- [x] No hardcoded values, magic numbers, or debug code left in

### Validation

- [ ] ~I have added/updated tests that cover my changes~
- [ ] ~I have tested across all relevant frameworks (React, Angular, Vue) if applicable~

### General

- [x] The PR title follows the conventional commits format (e.g. `feat:`, `fix:`, `chore:`), as in [Git Commit Conventions](docs/conventions.md#git-commits-conventions)
- [ ] If architecture, structure, or conventions changed inside a `packages/*` folder, the corresponding `AGENTS.md` has been updated
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/refactor-set-pr-draft-status-to-always-for-release-workflow>

<!-- DBUX-TEST-URL-END -->