### PR TITLE
chore: testing #7128 in the general pipeline

### DIFF
--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -47,7 +47,7 @@ const recommended = {
 		'db-ux/text-or-children-required': 'error',
 		'db-ux/tooltip-requires-interactive-parent': 'error'
 	}
-};
+} as const;
 
 const plugin = {
 	meta: {


### PR DESCRIPTION
## Proposed changes

We'd like to test https://github.com/db-ux-design-system/core-web/pull/7128 within our pipeline, nothing more, nothing less. And we'll still use https://github.com/db-ux-design-system/core-web/pull/7128 to merge it to `main`
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/chore-testing-#7128-in-the-general-pipeline>

<!-- DBUX-TEST-URL-END -->