### PR TITLE
refactor: added further conditions for `button[type="button"]`

### DIFF
--- a/.changeset/salty-socks-tan.md
+++ b/.changeset/salty-socks-tan.md
@@ -1,5 +1,8 @@
 ---
-"@db-ux/core-components": patch
+"@db-ux/ngx-core-components": patch
+"@db-ux/react-core-components": patch
+"@db-ux/wc-core-components": patch
+"@db-ux/v-core-components": patch
 ---
 
 refactor(button): correctly setting the `type` when nested in `<usermedia>` or `<geolocation>` HTML elements

--- a/.changeset/salty-socks-tan.md
+++ b/.changeset/salty-socks-tan.md
@@ -1,0 +1,5 @@
+---
+"@db-ux/core-components": patch
+---
+
+refactor(button): correctly setting the `type` when nested in `<usermedia>` or `<geolocation>` HTML elements

--- a/.changeset/salty-socks-tan.md
+++ b/.changeset/salty-socks-tan.md
@@ -3,6 +3,7 @@
 "@db-ux/react-core-components": patch
 "@db-ux/wc-core-components": patch
 "@db-ux/v-core-components": patch
+"@db-ux/core-eslint-plugin": patch
 ---
 
 refactor(button): correctly setting the `type` when nested in `<usermedia>` or `<geolocation>` HTML elements

--- a/.config/cspellignorewords.txt
+++ b/.config/cspellignorewords.txt
@@ -232,3 +232,4 @@ knip
 checkin
 focusgroup
 unprovide
+usermedia

--- a/packages/components/src/components/button/button.lite.tsx
+++ b/packages/components/src/components/button/button.lite.tsx
@@ -1,4 +1,5 @@
 import {
+	onMount,
 	Show,
 	useDefaultProps,
 	useMetadata,
@@ -20,17 +21,24 @@ export default function DBButton(props: DBButtonProps) {
 	const _ref = useRef<HTMLButtonElement | any>(null);
 
 	const state = useStore<DBButtonState>({
+		_isInsidePermissionElement: false,
 		getButtonType: () => {
 			if (props.type) {
 				return props.type;
 			} else if (
 				props.onClick ||
 				props.commandfor ||
-				_ref?.closest('usermedia, geolocation')
+				state._isInsidePermissionElement
 			) {
 				return 'button';
 			}
 			return 'submit';
+		}
+	});
+
+	onMount(() => {
+		if (_ref?.closest('usermedia, geolocation')) {
+			state._isInsidePermissionElement = true;
 		}
 	});
 

--- a/packages/components/src/components/button/button.lite.tsx
+++ b/packages/components/src/components/button/button.lite.tsx
@@ -23,9 +23,11 @@ export default function DBButton(props: DBButtonProps) {
 		getButtonType: () => {
 			if (props.type) {
 				return props.type;
-			} else if (props.onClick) {
-				return 'button';
-			} else if (props.commandfor) {
+			} else if (
+				props.onClick ||
+				props.commandfor ||
+				_ref?.closest('usermedia, geolocation')
+			) {
 				return 'button';
 			}
 			return 'submit';

--- a/packages/components/src/components/button/button.spec.tsx
+++ b/packages/components/src/components/button/button.spec.tsx
@@ -139,29 +139,27 @@ const testButtonType = () => {
 	});
 
 	test('should be type="button" when wrapped in a usermedia element', async ({
-		mount,
-		page
+		mount
 	}) => {
-		await page.setContent('<usermedia><div id="mount"></div></usermedia>');
-		const component = await mount(<DBButton>Test</DBButton>, {
-			hooksConfig: undefined,
-			selector: '#mount'
-		});
-		await expect(component).toHaveAttribute('type', 'button');
+		const component = await mount(
+			<usermedia>
+				<DBButton>Test</DBButton>
+			</usermedia>
+		);
+		const button = component.locator('.db-button');
+		await expect(button).toHaveAttribute('type', 'button');
 	});
 
 	test('should be type="button" when wrapped in a geolocation element', async ({
-		mount,
-		page
+		mount
 	}) => {
-		await page.setContent(
-			'<geolocation><div id="mount"></div></geolocation>'
+		const component = await mount(
+			<geolocation>
+				<DBButton>Test</DBButton>
+			</geolocation>
 		);
-		const component = await mount(<DBButton>Test</DBButton>, {
-			hooksConfig: undefined,
-			selector: '#mount'
-		});
-		await expect(component).toHaveAttribute('type', 'button');
+		const button = component.locator('.db-button');
+		await expect(button).toHaveAttribute('type', 'button');
 	});
 };
 

--- a/packages/components/src/components/button/button.spec.tsx
+++ b/packages/components/src/components/button/button.spec.tsx
@@ -105,9 +105,70 @@ const testAction = () => {
 	});
 };
 
+const testButtonType = () => {
+	test('should default to type="submit" without onClick or commandfor', async ({
+		mount
+	}) => {
+		const component = await mount(<DBButton>Test</DBButton>);
+		await expect(component).toHaveAttribute('type', 'submit');
+	});
+
+	test('should use explicit type prop when provided', async ({ mount }) => {
+		const component = await mount(<DBButton type="reset">Test</DBButton>);
+		await expect(component).toHaveAttribute('type', 'reset');
+	});
+
+	test('should be type="button" when onClick is provided', async ({
+		mount
+	}) => {
+		const component = await mount(
+			<DBButton onClick={() => {}}>Test</DBButton>
+		);
+		await expect(component).toHaveAttribute('type', 'button');
+	});
+
+	test('should be type="button" when commandfor is provided', async ({
+		mount
+	}) => {
+		const component = await mount(
+			<DBButton command="show-modal" commandfor="my-dialog">
+				Test
+			</DBButton>
+		);
+		await expect(component).toHaveAttribute('type', 'button');
+	});
+
+	test('should be type="button" when wrapped in a usermedia element', async ({
+		mount,
+		page
+	}) => {
+		await page.setContent('<usermedia><div id="mount"></div></usermedia>');
+		const component = await mount(<DBButton>Test</DBButton>, {
+			hooksConfig: undefined,
+			selector: '#mount'
+		});
+		await expect(component).toHaveAttribute('type', 'button');
+	});
+
+	test('should be type="button" when wrapped in a geolocation element', async ({
+		mount,
+		page
+	}) => {
+		await page.setContent(
+			'<geolocation><div id="mount"></div></geolocation>'
+		);
+		const component = await mount(<DBButton>Test</DBButton>, {
+			hooksConfig: undefined,
+			selector: '#mount'
+		});
+		await expect(component).toHaveAttribute('type', 'button');
+	});
+};
+
 test.describe('DBButton', () => {
 	test.use({ viewport: DEFAULT_VIEWPORT });
 	testButton();
 	testA11y();
 	testAction();
+	testButtonType();
 });

--- a/packages/components/src/components/button/model.ts
+++ b/packages/components/src/components/button/model.ts
@@ -86,7 +86,7 @@ export type DBButtonProps = DBButtonDefaultProps &
 	NoTextProps;
 
 export type DBButtonDefaultState = {
-	_isInsidePermissionElement: boolean;
+	_isInsidePermissionElement?: boolean;
 	getButtonType: () => ButtonTypeType;
 };
 

--- a/packages/components/src/components/button/model.ts
+++ b/packages/components/src/components/button/model.ts
@@ -86,6 +86,7 @@ export type DBButtonProps = DBButtonDefaultProps &
 	NoTextProps;
 
 export type DBButtonDefaultState = {
+	_isInsidePermissionElement: boolean;
 	getButtonType: () => ButtonTypeType;
 };
 

--- a/packages/eslint-plugin/src/rules/button/button-type-required.ts
+++ b/packages/eslint-plugin/src/rules/button/button-type-required.ts
@@ -28,7 +28,14 @@ export default {
 			let { parent } = node;
 			while (parent) {
 				if (['Element', 'Element$1'].includes(parent.type)) {
-					if (PERMISSION_ELEMENTS.has(parent.name?.toLowerCase())) {
+					// Only match native (already lowercase) tag names.
+					// PascalCase components like <Geolocation> are not
+					// native permission elements.
+					if (
+						parent.name &&
+						parent.name === parent.name.toLowerCase() &&
+						PERMISSION_ELEMENTS.has(parent.name)
+					) {
 						return true;
 					}
 				} else if (
@@ -44,7 +51,12 @@ export default {
 							: parentName?.type === 'JSXIdentifier'
 								? parentName.name
 								: null;
-					if (name && PERMISSION_ELEMENTS.has(name.toLowerCase())) {
+					// Only match native (already lowercase) tag names.
+					if (
+						name &&
+						name === name.toLowerCase() &&
+						PERMISSION_ELEMENTS.has(name)
+					) {
 						return true;
 					}
 				}

--- a/packages/eslint-plugin/src/rules/button/button-type-required.ts
+++ b/packages/eslint-plugin/src/rules/button/button-type-required.ts
@@ -22,13 +22,51 @@ export default {
 		schema: []
 	},
 	create(context: any) {
+		const PERMISSION_ELEMENTS = new Set(['usermedia', 'geolocation']);
+
+		const hasPermissionElementAncestor = (node: any): boolean => {
+			let { parent } = node;
+			while (parent) {
+				if (['Element', 'Element$1'].includes(parent.type)) {
+					if (PERMISSION_ELEMENTS.has(parent.name?.toLowerCase())) {
+						return true;
+					}
+				} else if (
+					parent.type === 'JSXElement' ||
+					parent.type === 'VElement'
+				) {
+					const parentOpening = parent.openingElement || parent;
+					const parentName =
+						parentOpening.name || parentOpening.rawName;
+					const name =
+						typeof parentName === 'string'
+							? parentName
+							: parentName?.type === 'JSXIdentifier'
+								? parentName.name
+								: null;
+					if (name && PERMISSION_ELEMENTS.has(name.toLowerCase())) {
+						return true;
+					}
+				}
+
+				parent = parent.parent;
+			}
+			return false;
+		};
+
 		const angularHandler = (node: any, parserServices: any) => {
 			const type = getAttributeValue(node, 'type');
 			if (type === undefined) {
 				const hasClickHandler = getAttributeValue(node, '(click)');
 				const hasCommandFor = getAttributeValue(node, 'commandfor');
+				const isInsidePermissionElement =
+					hasPermissionElementAncestor(node);
 				const typeValue =
-					hasClickHandler || hasCommandFor ? 'button' : 'submit';
+					hasClickHandler ||
+					hasCommandFor ||
+					isInsidePermissionElement
+						? 'button'
+						: 'submit';
 				const loc = parserServices.convertNodeSourceSpanToLoc(
 					node.sourceSpan
 				);
@@ -78,9 +116,13 @@ export default {
 				getAttributeValue(openingElement, '(click)') ||
 				getAttributeValue(openingElement, '@click');
 
+			const isInsidePermissionElement =
+				hasPermissionElementAncestor(node);
+
 			const typeValue =
 				hasClickHandler ||
-				getAttributeValue(openingElement, 'commandfor')
+				getAttributeValue(openingElement, 'commandfor') ||
+				isInsidePermissionElement
 					? 'button'
 					: 'submit';
 

--- a/packages/eslint-plugin/test/rules/button/button-type-required.spec.ts
+++ b/packages/eslint-plugin/test/rules/button/button-type-required.spec.ts
@@ -67,6 +67,18 @@ describe('button-type-required', () => {
 				code: '<usermedia><div><DBButton>Nested</DBButton></div></usermedia>',
 				errors: [{ messageId: 'missingType' }],
 				output: '<usermedia><div><DBButton type="button">Nested</DBButton></div></usermedia>'
+			},
+			{
+				// PascalCase component names are not native permission elements
+				code: '<Geolocation><DBButton>Submit</DBButton></Geolocation>',
+				errors: [{ messageId: 'missingType' }],
+				output: '<Geolocation><DBButton type="submit">Submit</DBButton></Geolocation>'
+			},
+			{
+				// PascalCase component names are not native permission elements
+				code: '<Usermedia><DBButton>Submit</DBButton></Usermedia>',
+				errors: [{ messageId: 'missingType' }],
+				output: '<Usermedia><DBButton type="submit">Submit</DBButton></Usermedia>'
 			}
 		]
 	});

--- a/packages/eslint-plugin/test/rules/button/button-type-required.spec.ts
+++ b/packages/eslint-plugin/test/rules/button/button-type-required.spec.ts
@@ -52,6 +52,21 @@ describe('button-type-required', () => {
 				code: '<DBButton commandfor="dialog">Toggle</DBButton>',
 				errors: [{ messageId: 'missingType' }],
 				output: '<DBButton commandfor="dialog" type="button">Toggle</DBButton>'
+			},
+			{
+				code: '<usermedia><DBButton>Grant Access</DBButton></usermedia>',
+				errors: [{ messageId: 'missingType' }],
+				output: '<usermedia><DBButton type="button">Grant Access</DBButton></usermedia>'
+			},
+			{
+				code: '<geolocation><DBButton>Share Location</DBButton></geolocation>',
+				errors: [{ messageId: 'missingType' }],
+				output: '<geolocation><DBButton type="button">Share Location</DBButton></geolocation>'
+			},
+			{
+				code: '<usermedia><div><DBButton>Nested</DBButton></div></usermedia>',
+				errors: [{ messageId: 'missingType' }],
+				output: '<usermedia><div><DBButton type="button">Nested</DBButton></div></usermedia>'
 			}
 		]
 	});
@@ -75,6 +90,16 @@ describe('button-type-required', () => {
 				code: '<db-button commandfor="dialog">Toggle</db-button>',
 				errors: [{ messageId: 'missingType' }],
 				output: '<db-button commandfor="dialog" type="button">Toggle</db-button>'
+			},
+			{
+				code: '<usermedia><db-button>Grant Access</db-button></usermedia>',
+				errors: [{ messageId: 'missingType' }],
+				output: '<usermedia><db-button type="button">Grant Access</db-button></usermedia>'
+			},
+			{
+				code: '<geolocation><db-button>Share Location</db-button></geolocation>',
+				errors: [{ messageId: 'missingType' }],
+				output: '<geolocation><db-button type="button">Share Location</db-button></geolocation>'
 			}
 		]
 	});


### PR DESCRIPTION
## Proposed changes

With the new `<usermedia>` and `<geolocation>` elements wrapping a `button`, this `button` is actually of `type` `button` instead of `submit`. This even also needs to get corrected in our `eslint` plugin.

## Checklist

### Code Quality

- [x] I have reviewed my own code (self-review), including the screen- and snapshots
- [x] I have reviewed my changes locally with an AI assistant (e.g. GitHub Copilot, Kiro, etc.)
- [x] No hardcoded values, magic numbers, or debug code left in

### Validation

- [x] I have added/updated tests that cover my changes
- [ ] ~I have tested across all relevant frameworks (React, Angular, Vue) if applicable~

### General

- [x] The PR title follows the conventional commits format (e.g. `feat:`, `fix:`, `chore:`), as in [Git Commit Conventions](docs/conventions.md#git-commits-conventions)
- [ ] If architecture, structure, or conventions changed inside a `packages/*` folder, the corresponding `AGENTS.md` has been updated
