### PR TITLE
refactor: prevent placeholder from being hidden when select is opened

### DIFF
--- a/.changeset/fix-select-placeholder-on-open.md
+++ b/.changeset/fix-select-placeholder-on-open.md
@@ -6,4 +6,4 @@
 "@db-ux/v-core-components": patch
 ---
 
-fix: prevent placeholder from being hidden when select is opened
+refactor: prevent placeholder from being hidden when select is opened

--- a/.changeset/fix-select-placeholder-on-open.md
+++ b/.changeset/fix-select-placeholder-on-open.md
@@ -1,0 +1,9 @@
+---
+"@db-ux/core-components": patch
+"@db-ux/ngx-core-components": patch
+"@db-ux/react-core-components": patch
+"@db-ux/wc-core-components": patch
+"@db-ux/v-core-components": patch
+---
+
+fix: prevent placeholder from being hidden when select is opened

--- a/packages/components/src/components/select/select.scss
+++ b/packages/components/src/components/select/select.scss
@@ -51,14 +51,6 @@
 		background-color: colors.$db-adaptive-bg-basic-level-3-default;
 	}
 
-	select:is(:has(option:checked:not(.placeholder))) {
-		& ~ [id$="-placeholder"],
-		// Hide the placeholder and an inserted empty `option` with
-		// `data-show-empty-option="false"` once a non-placeholder option is selected or the `select` is open
-		option[data-show-empty-option="false"] {
-			display: none;
-		}
-	}
 	select:has(option:checked:not(.placeholder)) {
 		// Hide the placeholder once a non-placeholder option is selected
 		& ~ [id$="-placeholder"] {

--- a/packages/components/src/components/select/select.scss
+++ b/packages/components/src/components/select/select.scss
@@ -39,10 +39,11 @@
 		&:has(option:checked:not(.placeholder)) ~ [id$="-placeholder"] {
 			display: none;
 		}
-		
+
 		// Hide an inserted empty `option` with `data-show-empty-option="false"`
 		// once a non-placeholder option is selected or the `select` is open
-		&:is(:has(option:checked:not(.placeholder)), :open) option[data-show-empty-option="false"] {
+		&:is(:has(option:checked:not(.placeholder)), :open)
+			option[data-show-empty-option="false"] {
 			display: none;
 		}
 	}

--- a/packages/components/src/components/select/select.scss
+++ b/packages/components/src/components/select/select.scss
@@ -59,4 +59,17 @@
 			display: none;
 		}
 	}
-}
+	select:has(option:checked:not(.placeholder)) {
+		// Hide the placeholder once a non-placeholder option is selected
+		& ~ [id$="-placeholder"] {
+			display: none;
+		}
+	}
+
+	select:is(:has(option:checked:not(.placeholder)), :open) {
+		// Hide an inserted empty `option` with `data-show-empty-option="false"`
+		// once a non-placeholder option is selected or the `select` is open
+		option[data-show-empty-option="false"] {
+			display: none;
+		}
+	}

--- a/packages/components/src/components/select/select.scss
+++ b/packages/components/src/components/select/select.scss
@@ -51,7 +51,7 @@
 		background-color: colors.$db-adaptive-bg-basic-level-3-default;
 	}
 
-	select:is(:has(option:checked:not(.placeholder)), :open) {
+	select:is(:has(option:checked:not(.placeholder))) {
 		& ~ [id$="-placeholder"],
 		// Hide the placeholder and an inserted empty `option` with
 		// `data-show-empty-option="false"` once a non-placeholder option is selected or the `select` is open

--- a/packages/components/src/components/select/select.scss
+++ b/packages/components/src/components/select/select.scss
@@ -35,19 +35,15 @@
 	select {
 		text-indent: select-components.$has-before-padding;
 
-		&:has(option:checked:not(.placeholder)) {
-			// Hide the placeholder once a non-placeholder option is selected
-			& ~ [id$="-placeholder"] {
-				display: none;
-			}
+		// Hide the placeholder once a non-placeholder option is selected
+		&:has(option:checked:not(.placeholder)) ~ [id$="-placeholder"] {
+			display: none;
 		}
-	
-		&:is(:has(option:checked:not(.placeholder)), :open) {
-			// Hide an inserted empty `option` with `data-show-empty-option="false"`
-			// once a non-placeholder option is selected or the `select` is open
-			option[data-show-empty-option="false"] {
-				display: none;
-			}
+		
+		// Hide an inserted empty `option` with `data-show-empty-option="false"`
+		// once a non-placeholder option is selected or the `select` is open
+		&:is(:has(option:checked:not(.placeholder)), :open) option[data-show-empty-option="false"] {
+			display: none;
 		}
 	}
 

--- a/packages/components/src/components/select/select.scss
+++ b/packages/components/src/components/select/select.scss
@@ -34,6 +34,21 @@
 
 	select {
 		text-indent: select-components.$has-before-padding;
+
+		&:has(option:checked:not(.placeholder)) {
+			// Hide the placeholder once a non-placeholder option is selected
+			& ~ [id$="-placeholder"] {
+				display: none;
+			}
+		}
+	
+		&:is(:has(option:checked:not(.placeholder)), :open) {
+			// Hide an inserted empty `option` with `data-show-empty-option="false"`
+			// once a non-placeholder option is selected or the `select` is open
+			option[data-show-empty-option="false"] {
+				display: none;
+			}
+		}
 	}
 
 	&[data-hide-label="true"] {
@@ -50,18 +65,4 @@
 	optgroup {
 		background-color: colors.$db-adaptive-bg-basic-level-3-default;
 	}
-
-	select:has(option:checked:not(.placeholder)) {
-		// Hide the placeholder once a non-placeholder option is selected
-		& ~ [id$="-placeholder"] {
-			display: none;
-		}
-	}
-
-	select:is(:has(option:checked:not(.placeholder)), :open) {
-		// Hide an inserted empty `option` with `data-show-empty-option="false"`
-		// once a non-placeholder option is selected or the `select` is open
-		option[data-show-empty-option="false"] {
-			display: none;
-		}
-	}
+}


### PR DESCRIPTION
## Proposed changes

As a follow up to https://github.com/db-ux-design-system/core-web/pull/6477 we'd like to not hide the placeholder anymore on an open `select` (as soon as the `option` elements are being shown).

## Checklist

### Code Quality

- [x] I have reviewed my own code (self-review), including the screen- and snapshots
- [x] I have reviewed my changes locally with an AI assistant (e.g. GitHub Copilot, Kiro, etc.)
- [x] No hardcoded values, magic numbers, or debug code left in

### Validation

- [ ] ~I have added/updated tests that cover my changes~
- [x] I have tested across all relevant frameworks (React, Angular, Vue) if applicable

### General

- [x] The PR title follows the conventional commits format (e.g. `feat:`, `fix:`, `chore:`), as in [Git Commit Conventions](docs/conventions.md#git-commits-conventions)
- [x] If architecture, structure, or conventions changed inside a `packages/*` folder, the corresponding `AGENTS.md` has been updated
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/fix-select-hiden-placeholder-on-open>

<!-- DBUX-TEST-URL-END -->