### PR TITLE
ci(pnpm): debug publish

### DIFF
--- a/.changeset/hip-canyons-serve.md
+++ b/.changeset/hip-canyons-serve.md
@@ -1,0 +1,5 @@
+---
+"@db-ux/mcp-server": patch
+---
+
+_version bump_

--- a/scripts/github/publish-npm.js
+++ b/scripts/github/publish-npm.js
@@ -130,7 +130,8 @@ for (const step of IS_CI ? ['dry-run', 'provenance'] : ['dry-run']) {
 		console.log(`⤴ (${step}) Publish ${PACKAGE} with tag ${TAG} to NPM`);
 		try {
 			execSync(
-				`pnpm publish --tag ${TAG} ${path.join(buildOutputs, dir, `db-ux-${PACKAGE}-${VALID_SEMVER}.tgz`)} --${step} --no-git-checks`
+				`pnpm publish --tag ${TAG} ${path.join(buildOutputs, dir, `db-ux-${PACKAGE}-${VALID_SEMVER}.tgz`)} --${step} --no-git-checks`,
+				{ stdio: 'inherit' }
 			);
 		} catch (error) {
 			console.error(


### PR DESCRIPTION
## Proposed changes

The publish step's `execSync` call was missing `stdio: 'inherit'`, which meant npm's actual error output (403s, token expiry, rate limits, etc.) was swallowed. Only the generic "Command failed: pnpm publish ..." string was logged, making it impossible to diagnose why the `mcp-server` provenance publish failed.

With this change, npm's stdout/stderr stream directly into the CI log — matching the behavior already used for `pnpm pack` and the registry config commands in the same script.

## Checklist

### Code Quality

- [x] I have reviewed my own code (self-review), including the screen- and snapshots
- [x] I have reviewed my changes locally with an AI assistant (e.g. GitHub Copilot, Kiro, etc.)
- [x] No hardcoded values, magic numbers, or debug code left in

### Validation

- [ ] ~I have added/updated tests that cover my changes~
- [ ] ~I have tested across all relevant frameworks (React, Angular, Vue) if applicable~

### General

- [x] The PR title follows the conventional commits format (e.g. `feat:`, `fix:`, `chore:`), as in [Git Commit Conventions](docs/conventions.md#git-commits-conventions)
- [ ] If architecture, structure, or conventions changed inside a `packages/*` folder, the corresponding `AGENTS.md` has been updated
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/ci-debug-pnpm-publish>

<!-- DBUX-TEST-URL-END -->