### PR TITLE
fix: layout issue with sub-navigation-item inside the mobile drawer

### DIFF
--- a/.changeset/wide-bikes-beg.md
+++ b/.changeset/wide-bikes-beg.md
@@ -1,0 +1,9 @@
+---
+"@db-ux/core-components": patch
+"@db-ux/ngx-core-components": patch
+"@db-ux/react-core-components": patch
+"@db-ux/wc-core-components": patch
+"@db-ux/v-core-components": patch
+---
+
+fix: layout issue with sub-navigation-item inside the mobile drawer

--- a/packages/components/src/components/drawer/drawer.scss
+++ b/packages/components/src/components/drawer/drawer.scss
@@ -7,12 +7,14 @@
 @use "../../styles/dialog-init";
 
 %container-size-horizontal {
-	inline-size: calc(
+	--db-drawer-width-horizontal: calc(
 		var(--db-drawer-inline-size) - var(
 				--db-drawer-container-backdrop-spacing,
 				0px
 			)
 	);
+
+	inline-size: var(--db-drawer-width-horizontal);
 	min-inline-size: var(--db-drawer-min-width, auto);
 	max-inline-size: var(
 		--db-drawer-max-width,

--- a/packages/components/src/components/navigation-item/navigation-item.scss
+++ b/packages/components/src/components/navigation-item/navigation-item.scss
@@ -166,10 +166,10 @@
 	}
 }
 
-@mixin sub-navigation-mobile() {
+@mixin sub-navigation-item-mobile() {
 	padding: variables.$db-spacing-fixed-xs
 		component.$drawer-content-padding-inline;
-	inline-size: 100%;
+	inline-size: var(--db-drawer-width-horizontal, 100%);
 	max-inline-size: var(
 		--db-drawer-max-width,
 		var(--db-drawer-max-width-horizontal)
@@ -186,8 +186,6 @@
 }
 
 .db-sub-navigation {
-	@extend %component-border;
-
 	margin: 0;
 
 	@include helpers.display(flex);
@@ -198,16 +196,12 @@
 	visibility: hidden;
 
 	@include screen-sizes.screen("md", "max") {
-		@include sub-navigation-mobile;
+		@include sub-navigation-item-mobile;
 	}
 
 	@include screen-sizes.screen("md") {
-		.db-mobile-navigation-back {
-			@include helpers.display(none);
-		}
-	}
-
-	@include screen-sizes.screen("md") {
+		// stylelint-disable-next-line db-ux/use-border-width, db-ux/use-border-color
+		border: component.$component-border;
 		border-radius: variables.$db-border-radius-sm;
 		box-shadow: variables.$db-elevation-md;
 		padding: variables.$db-spacing-fixed-sm;
@@ -215,6 +209,10 @@
 		min-inline-size: variables.$db-container-xs;
 		inset-block-start: calc(100% + #{variables.$db-spacing-fixed-md});
 		transition: visibility 1ms linear; // workaround to enable focus with keyboard
+
+		.db-mobile-navigation-back {
+			@include helpers.display(none);
+		}
 
 		&[data-outside-vx="true"] {
 			transform: translateX(-100%);


### PR DESCRIPTION
## Proposed changes

Fixes a layout issue where the sub-navigation-item inside the mobile drawer did not respect the drawer's width, causing overflow or misalignment.

**Changes:**

- Extracted the drawer's computed `inline-size` into a CSS custom property (`--db-drawer-width-horizontal`) so child components can reference it
- Updated `.db-sub-navigation` on mobile to use `var(--db-drawer-width-horizontal, 100%)` instead of a hardcoded `100%`, ensuring the sub-navigation-item matches the actual drawer width
- Moved the `border` declaration and `.db-mobile-navigation-back` hiding into the `md` (desktop) media query where they belong, removing them from the mobile path
- Removed an unnecessary `@extend %component-border` that applied desktop-only border styles globally
- Renamed the internal mixin from `sub-navigation-mobile` to `sub-navigation-item-mobile` for clarity

## Checklist

### Code Quality

- [ ] I have reviewed my own code (self-review), including the screen- and snapshots
- [ ] I have reviewed my changes locally with an AI assistant (e.g. GitHub Copilot, Kiro, etc.)
- [ ] No hardcoded values, magic numbers, or debug code left in

### Validation

- [ ] I have added/updated tests that cover my changes
- [ ] I have tested across all relevant frameworks (React, Angular, Vue) if applicable

### General

- [x] The PR title follows the conventional commits format (e.g. `feat:`, `fix:`, `chore:`), as in [Git Commit Conventions](docs/conventions.md#git-commits-conventions)
- [ ] If architecture, structure, or conventions changed inside a `packages/*` folder, the corresponding `AGENTS.md` has been updated
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/fix-mobile-sub-navigation-item>

<!-- DBUX-TEST-URL-END -->