### PR TITLE
fix: allow auto-width tab items to fit content

### DIFF
--- a/.changeset/gentle-tabs-expand.md
+++ b/.changeset/gentle-tabs-expand.md
@@ -1,5 +1,9 @@
 ---
 "@db-ux/core-components": patch
+"@db-ux/ngx-core-components": patch
+"@db-ux/react-core-components": patch
+"@db-ux/wc-core-components": patch
+"@db-ux/v-core-components": patch
 ---
 
 fix: allow auto-width tab items to fit their complete content

--- a/.changeset/gentle-tabs-expand.md
+++ b/.changeset/gentle-tabs-expand.md
@@ -1,0 +1,5 @@
+---
+"@db-ux/core-components": patch
+---
+
+fix: allow auto-width tab items to fit their complete content

--- a/packages/components/src/components/tab-item/tab-item.scss
+++ b/packages/components/src/components/tab-item/tab-item.scss
@@ -19,7 +19,6 @@
 	font: inherit;
 	color: colors.$db-adaptive-on-bg-basic-emphasis-100-default;
 	flex-shrink: 0;
-	max-inline-size: variables.$db-sizing-2xl;
 
 	@extend %transparent-border;
 

--- a/packages/components/src/components/tabs/tabs.scss
+++ b/packages/components/src/components/tabs/tabs.scss
@@ -176,7 +176,6 @@ $focus-outline-reach: calc(
 		&:not([data-orientation="vertical"]) .db-tab-item {
 			flex: 1 0 0;
 			inline-size: 0;
-			max-inline-size: none;
 			justify-content: flex-start;
 		}
 

--- a/packages/components/src/components/tabs/tabs.spec.tsx
+++ b/packages/components/src/components/tabs/tabs.spec.tsx
@@ -187,10 +187,110 @@ const testProps = () => {
 	});
 };
 
+const testTabItemWidth = () => {
+	// Regression guard for https://github.com/db-ux-design-system/core-web/issues/7405:
+	// tab items must not be clipped by a global maximum width.
+	test('should not limit the width of horizontal auto-width tab items', async ({
+		mount,
+		page
+	}) => {
+		await page.setViewportSize({ width: 1920, height: 1080 });
+		const longLabel =
+			'Tab item with a very long label that must not be cut off';
+		const component = await mount(
+			<DBTabs tabItemWidth="auto">
+				<DBTabList>
+					<DBTabItem icon="x_placeholder">{longLabel}</DBTabItem>
+					<DBTabItem>Short</DBTabItem>
+				</DBTabList>
+				<DBTabPanel>Panel 1</DBTabPanel>
+				<DBTabPanel>Panel 2</DBTabPanel>
+			</DBTabs>
+		);
+
+		const tab = component.getByRole('tab', { name: longLabel });
+		await expect(tab).toHaveCSS('max-inline-size', 'none');
+
+		// The removed hard cap was `$db-sizing-2xl` (10rem = 160px).
+		const tabWidth = await tab.evaluate(
+			(element) => element.getBoundingClientRect().width
+		);
+		expect(tabWidth).toBeGreaterThan(160);
+
+		// The label text must be rendered completely instead of being cut off.
+		const labelMetrics = await tab
+			.locator('.db-tab-item-label-text')
+			.evaluate((element) => ({
+				clientWidth: element.clientWidth,
+				scrollWidth: element.scrollWidth
+			}));
+		expect(labelMetrics.scrollWidth).toBeLessThanOrEqual(
+			labelMetrics.clientWidth + 1
+		);
+	});
+
+	test('should keep truncating vertical tab items', async ({ mount }) => {
+		const longLabel =
+			'Very long vertical tab label that definitely gets truncated';
+		const component = await mount(
+			<DBTabs orientation="vertical" tabItemWidth="auto">
+				<DBTabList>
+					<DBTabItem>{longLabel}</DBTabItem>
+					<DBTabItem>Short</DBTabItem>
+				</DBTabList>
+				<DBTabPanel>Panel 1</DBTabPanel>
+				<DBTabPanel>Panel 2</DBTabPanel>
+			</DBTabs>
+		);
+
+		const tab = component.getByRole('tab', { name: longLabel });
+		const labelMetrics = await tab
+			.locator('.db-tab-item-label-text')
+			.evaluate((element) => ({
+				clientWidth: element.clientWidth,
+				scrollWidth: element.scrollWidth
+			}));
+		expect(labelMetrics.scrollWidth).toBeGreaterThan(
+			labelMetrics.clientWidth
+		);
+
+		// Truncated labels stay readable via the built-in truncation tooltip.
+		await expect(tab.locator('.db-tooltip')).toBeAttached();
+	});
+
+	test('should stretch full-width tab items equally', async ({
+		mount,
+		page
+	}) => {
+		await page.setViewportSize({ width: 1920, height: 1080 });
+		const component = await mount(
+			<DBTabs tabItemWidth="full">
+				<DBTabList>
+					<DBTabItem>Short</DBTabItem>
+					<DBTabItem>
+						A considerably longer full-width tab item label
+					</DBTabItem>
+				</DBTabList>
+				<DBTabPanel>Panel 1</DBTabPanel>
+				<DBTabPanel>Panel 2</DBTabPanel>
+			</DBTabs>
+		);
+
+		const widths = await component
+			.getByRole('tab')
+			.evaluateAll((elements) =>
+				elements.map((element) => element.getBoundingClientRect().width)
+			);
+		expect(widths).toHaveLength(2);
+		expect(Math.abs(widths[0] - widths[1])).toBeLessThanOrEqual(1);
+	});
+};
+
 test.describe('DBTabs', () => {
 	test.use({ viewport: DEFAULT_VIEWPORT });
 	testComponent();
 	testA11y();
 	testActions();
 	testProps();
+	testTabItemWidth();
 });


### PR DESCRIPTION
## Proposed changes

Removes the global `2xl` maximum width from `DBTabItem`. This allows horizontal auto-width tab items to display long labels, wide icons, and slot content without clipping. Existing width constraints for vertical and full-width tabs remain unchanged.

Includes a patch changeset for `@db-ux/core-components`.

Validation:

- `pnpm run build`
- `pnpm run test`
- `pnpm run lint`
- `pnpm run build-outputs`

resolves #7405

## Checklist

### Code Quality

- [x] I have reviewed my own code (self-review), including the screen- and snapshots
- [x] I have reviewed my changes locally with an AI assistant (e.g. GitHub Copilot, Kiro, etc.)
- [x] No hardcoded values, magic numbers, or debug code left in

### Validation

- [x] I have added/updated tests that cover my changes
- [x] I have tested across all relevant frameworks (React, Angular, Vue) if applicable

### General

- [x] The PR title follows the conventional commits format (e.g. `feat:`, `fix:`, `chore:`), as in [Git Commit Conventions](docs/conventions.md#git-commits-conventions)
- [x] If architecture, structure, or conventions changed inside a `packages/*` folder, the corresponding `AGENTS.md` has been updated
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/fix-tab-item-content-width-7405>

<!-- DBUX-TEST-URL-END -->