### PR TITLE
fix: re-run tooltip auto-placement when content changes

### DIFF
--- a/.changeset/fix-tooltip-placement-content-change.md
+++ b/.changeset/fix-tooltip-placement-content-change.md
@@ -1,5 +1,4 @@
 ---
-"@db-ux/core-components": patch
 "@db-ux/ngx-core-components": patch
 "@db-ux/react-core-components": patch
 "@db-ux/wc-core-components": patch

--- a/.changeset/fix-tooltip-placement-content-change.md
+++ b/.changeset/fix-tooltip-placement-content-change.md
@@ -1,0 +1,9 @@
+---
+"@db-ux/core-components": patch
+"@db-ux/ngx-core-components": patch
+"@db-ux/react-core-components": patch
+"@db-ux/wc-core-components": patch
+"@db-ux/v-core-components": patch
+---
+
+fix: re-run tooltip auto-placement when content changes

--- a/packages/components/src/components/tooltip/model.ts
+++ b/packages/components/src/components/tooltip/model.ts
@@ -42,6 +42,7 @@ export type DBTooltipDefaultState = {
 	_attachedParent?: HTMLElement;
 	_attachedId?: string;
 	_activeTriggerCount?: number;
+	_selfResizeObserverCallbackId?: string;
 	_boundListeners?: {
 		parent: HTMLElement;
 		type: string;

--- a/packages/components/src/components/tooltip/model.ts
+++ b/packages/components/src/components/tooltip/model.ts
@@ -43,7 +43,7 @@ export type DBTooltipDefaultState = {
 	_attachedId?: string;
 	_activeTriggerCount?: number;
 	_selfResizeObserverCallbackId?: string;
-	_isRepositioning?: boolean;
+	_lastPlacedSize?: { width: number; height: number };
 	_boundListeners?: {
 		parent: HTMLElement;
 		type: string;

--- a/packages/components/src/components/tooltip/model.ts
+++ b/packages/components/src/components/tooltip/model.ts
@@ -43,6 +43,7 @@ export type DBTooltipDefaultState = {
 	_attachedId?: string;
 	_activeTriggerCount?: number;
 	_selfResizeObserverCallbackId?: string;
+	_isRepositioning?: boolean;
 	_boundListeners?: {
 		parent: HTMLElement;
 		type: string;

--- a/packages/components/src/components/tooltip/tooltip.lite.tsx
+++ b/packages/components/src/components/tooltip/tooltip.lite.tsx
@@ -34,7 +34,7 @@ export default function DBTooltip(props: DBTooltipProps) {
 		_intersectionObserverCallbackId: undefined,
 		_resizeObserverCallbackId: undefined,
 		_selfResizeObserverCallbackId: undefined,
-		_isRepositioning: false,
+		_lastPlacedSize: undefined,
 		_attachedParent: undefined,
 		_attachedId: undefined,
 		_activeTriggerCount: 0,
@@ -68,13 +68,15 @@ export default function DBTooltip(props: DBTooltipProps) {
 				void utilsDelay(() => {
 					// Due to race conditions we need to check for _ref again
 					if (_ref) {
-						// Guard to prevent resize feedback loop: the
-						// placement code may constrain the tooltip size
-						// (e.g. maxBlockSize for outsideYBoth), which would
-						// re-trigger the self ResizeObserver.
-						state._isRepositioning = true;
 						handleFixedPopover(_ref, parent);
-						state._isRepositioning = false;
+						// Record the size after placement so the self
+						// ResizeObserver can distinguish placement-induced
+						// resizes from genuine content changes.
+						const rect = _ref.getBoundingClientRect();
+						state._lastPlacedSize = {
+							width: Math.round(rect.width),
+							height: Math.round(rect.height)
+						};
 					}
 				}, 1);
 			}
@@ -143,12 +145,18 @@ export default function DBTooltip(props: DBTooltipProps) {
 				// (e.g. toggling between "Expand"/"Collapse") trigger
 				// repositioning and arrow recalculation.
 				state._selfResizeObserverCallbackId =
-					new ResizeObserverListener().observe(_ref, () => {
-						// Skip if the resize was caused by our own
-						// placement logic (e.g. maxBlockSize constraint)
-						if (!state._isRepositioning) {
-							state.handleAutoPlacement(parent);
+					new ResizeObserverListener().observe(_ref, (entry) => {
+						// Skip if the new size matches what our placement
+						// code just set — this prevents an infinite loop
+						// when placement constrains the tooltip (e.g.
+						// maxBlockSize on mobile viewports).
+						const w = Math.round(entry.contentRect.width);
+						const h = Math.round(entry.contentRect.height);
+						const last = state._lastPlacedSize;
+						if (last && last.width === w && last.height === h) {
+							return;
 						}
+						state.handleAutoPlacement(parent);
 					});
 				const observeTarget = state.getParent();
 				if (observeTarget) {

--- a/packages/components/src/components/tooltip/tooltip.lite.tsx
+++ b/packages/components/src/components/tooltip/tooltip.lite.tsx
@@ -34,6 +34,7 @@ export default function DBTooltip(props: DBTooltipProps) {
 		_intersectionObserverCallbackId: undefined,
 		_resizeObserverCallbackId: undefined,
 		_selfResizeObserverCallbackId: undefined,
+		_isRepositioning: false,
 		_attachedParent: undefined,
 		_attachedId: undefined,
 		_activeTriggerCount: 0,
@@ -67,7 +68,13 @@ export default function DBTooltip(props: DBTooltipProps) {
 				void utilsDelay(() => {
 					// Due to race conditions we need to check for _ref again
 					if (_ref) {
+						// Guard to prevent resize feedback loop: the
+						// placement code may constrain the tooltip size
+						// (e.g. maxBlockSize for outsideYBoth), which would
+						// re-trigger the self ResizeObserver.
+						state._isRepositioning = true;
 						handleFixedPopover(_ref, parent);
+						state._isRepositioning = false;
 					}
 				}, 1);
 			}
@@ -136,9 +143,13 @@ export default function DBTooltip(props: DBTooltipProps) {
 				// (e.g. toggling between "Expand"/"Collapse") trigger
 				// repositioning and arrow recalculation.
 				state._selfResizeObserverCallbackId =
-					new ResizeObserverListener().observe(_ref, () =>
-						state.handleAutoPlacement(parent)
-					);
+					new ResizeObserverListener().observe(_ref, () => {
+						// Skip if the resize was caused by our own
+						// placement logic (e.g. maxBlockSize constraint)
+						if (!state._isRepositioning) {
+							state.handleAutoPlacement(parent);
+						}
+					});
 				const observeTarget = state.getParent();
 				if (observeTarget) {
 					state._intersectionObserverCallbackId =

--- a/packages/components/src/components/tooltip/tooltip.lite.tsx
+++ b/packages/components/src/components/tooltip/tooltip.lite.tsx
@@ -33,6 +33,7 @@ export default function DBTooltip(props: DBTooltipProps) {
 		_documentScrollListenerCallbackId: undefined,
 		_intersectionObserverCallbackId: undefined,
 		_resizeObserverCallbackId: undefined,
+		_selfResizeObserverCallbackId: undefined,
 		_attachedParent: undefined,
 		_attachedId: undefined,
 		_activeTriggerCount: 0,
@@ -101,6 +102,13 @@ export default function DBTooltip(props: DBTooltipProps) {
 				state._resizeObserverCallbackId = undefined;
 			}
 
+			if (state._selfResizeObserverCallbackId) {
+				new ResizeObserverListener().unobserve(
+					state._selfResizeObserverCallbackId!
+				);
+				state._selfResizeObserverCallbackId = undefined;
+			}
+
 			if (state._intersectionObserverCallbackId) {
 				new IntersectionObserverListener().unobserve(
 					state._intersectionObserverCallbackId!
@@ -123,6 +131,13 @@ export default function DBTooltip(props: DBTooltipProps) {
 					new ResizeObserverListener().observe(
 						document.documentElement,
 						() => state.handleAutoPlacement(parent)
+					);
+				// Observe the tooltip element itself so that content changes
+				// (e.g. toggling between "Expand"/"Collapse") trigger
+				// repositioning and arrow recalculation.
+				state._selfResizeObserverCallbackId =
+					new ResizeObserverListener().observe(_ref, () =>
+						state.handleAutoPlacement(parent)
 					);
 				const observeTarget = state.getParent();
 				if (observeTarget) {
@@ -157,6 +172,13 @@ export default function DBTooltip(props: DBTooltipProps) {
 					state._resizeObserverCallbackId!
 				);
 				state._resizeObserverCallbackId = undefined;
+			}
+
+			if (state._selfResizeObserverCallbackId) {
+				new ResizeObserverListener().unobserve(
+					state._selfResizeObserverCallbackId!
+				);
+				state._selfResizeObserverCallbackId = undefined;
 			}
 
 			if (state._intersectionObserverCallbackId) {

--- a/packages/components/src/components/tooltip/tooltip.lite.tsx
+++ b/packages/components/src/components/tooltip/tooltip.lite.tsx
@@ -145,13 +145,17 @@ export default function DBTooltip(props: DBTooltipProps) {
 				// (e.g. toggling between "Expand"/"Collapse") trigger
 				// repositioning and arrow recalculation.
 				state._selfResizeObserverCallbackId =
-					new ResizeObserverListener().observe(_ref, (entry) => {
+					new ResizeObserverListener().observe(_ref, () => {
 						// Skip if the new size matches what our placement
 						// code just set — this prevents an infinite loop
 						// when placement constrains the tooltip (e.g.
 						// maxBlockSize on mobile viewports).
-						const w = Math.round(entry.contentRect.width);
-						const h = Math.round(entry.contentRect.height);
+						// Use getBoundingClientRect (border box) for both
+						// recording and comparison to avoid a mismatch with
+						// entry.contentRect (content box) on padded elements.
+						const rect = _ref.getBoundingClientRect();
+						const w = Math.round(rect.width);
+						const h = Math.round(rect.height);
 						const last = state._lastPlacedSize;
 						if (last && last.width === w && last.height === h) {
 							return;


### PR DESCRIPTION
## Proposed changes

When the tooltip content changes (e.g. a toggle button switching between "Expand"/"Collapse"), the tooltip's dimensions change but `handleAutoPlacement` was not re-triggered. This caused the tooltip arrow to jump to an incorrect position.

The fix adds a `ResizeObserver` on the tooltip element itself (in addition to the existing one on `document.documentElement`). When the tooltip's own size changes due to content updates, the observer fires and recalculates the position and arrow placement.

resolves #7308

## Checklist

### Code Quality

- [x] I have reviewed my own code (self-review), including the screen- and snapshots
- [x] I have reviewed my changes locally with an AI assistant (e.g. GitHub Copilot, Kiro, etc.)
- [x] No hardcoded values, magic numbers, or debug code left in

### Validation

- [ ] I have added/updated tests that cover my changes
- [x] I have tested across all relevant frameworks (React, Angular, Vue) if applicable

### General

- [x] The PR title follows the conventional commits format (e.g. `feat:`, `fix:`, `chore:`), as in [Git Commit Conventions](docs/conventions.md#git-commits-conventions)
- [x] If architecture, structure, or conventions changed inside a `packages/*` folder, the corresponding `AGENTS.md` has been updated
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/fix-tooltip-placement-on-content-change>

<!-- DBUX-TEST-URL-END -->