### PR TITLE
fix(icon): preserve reserved height in Safari

### DIFF
--- a/.changeset/calm-icons-rest.md
+++ b/.changeset/calm-icons-rest.md
@@ -1,5 +1,9 @@
 ---
 "@db-ux/core-components": patch
+"@db-ux/ngx-core-components": patch
+"@db-ux/react-core-components": patch
+"@db-ux/wc-core-components": patch
+"@db-ux/v-core-components": patch
 ---
 
 fix: preserve the reserved icon height in Safari to prevent layout shifts

--- a/.changeset/calm-icons-rest.md
+++ b/.changeset/calm-icons-rest.md
@@ -1,0 +1,5 @@
+---
+"@db-ux/core-components": patch
+---
+
+fix: preserve the reserved icon height in Safari to prevent layout shifts

--- a/packages/components/src/components/icon/icon.scss
+++ b/packages/components/src/components/icon/icon.scss
@@ -4,12 +4,8 @@
 .db-icon {
 	@include icons.is-icon-text-replace;
 
-	/* Safari hack */
+	/* Safari needs inline-block for icon alignment. */
 	@supports (-webkit-hyphens: none) {
 		@include helpers.display(inline-block);
-
-		&::before {
-			block-size: auto;
-		}
 	}
 }


### PR DESCRIPTION
## Proposed changes

Removes the obsolete Safari-specific `block-size: auto` override from the DBIcon pseudo-element. This preserves the fixed dimensions from the shared icon styles while fonts load and prevents the initial layout shift.

Includes a patch changeset for `@db-ux/core-components`.

resolves #5558

## Checklist

### Code Quality

- [x] I have reviewed my own code (self-review), including the screen- and snapshots
- [x] I have reviewed my changes locally with an AI assistant (e.g. GitHub Copilot, Kiro, etc.)
- [x] No hardcoded values, magic numbers, or debug code left in

### Validation

- [ ] I have added/updated tests that cover my changes
- [ ] I have tested across all relevant frameworks (React, Angular, Vue) if applicable

### General

- [x] The PR title follows the conventional commits format (e.g. `feat:`, `fix:`, `chore:`), as in [Git Commit Conventions](docs/conventions.md#git-commits-conventions)
- [x] If architecture, structure, or conventions changed inside a `packages/*` folder, the corresponding `AGENTS.md` has been updated

## Validation notes

- `pnpm run build` passed.
- `pnpm run test` passed.
- Targeted Stylelint, Prettier, Markdownlint, and `git diff --check` passed.
- The WebKit runtime check could not run because the matching Playwright WebKit binary is not installed locally.
- `pnpm run lint` is blocked by spelling findings in the generated, untracked `packages/foundations/playwright-report/**`.
- `pnpm run build-outputs` is blocked by unrelated existing Vue heading type errors in `output/vue/src/components/heading/heading.vue`.
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/fix-5558-webkit-icon-layout-shift>

<!-- DBUX-TEST-URL-END -->