### PR TITLE
chore: run corepack to update pnpm with dependabot

### DIFF
--- a/.github/workflows/99-audit-fix-dependabot.yml
+++ b/.github/workflows/99-audit-fix-dependabot.yml
@@ -33,6 +33,9 @@ jobs:
           ASSET_INIT_VECTOR: ${{ secrets.ASSET_INIT_VECTOR }}
           ASSET_PASSWORD: ${{ secrets.ASSET_PASSWORD }}
 
+      - name: 📦 Run corepack to update pnpm
+        run: corepack use pnpm@latest
+
       - name: 🔒 Run pnpm audit --fix=update
         run: pnpm audit --fix=update || true
 

--- a/showcases/patternhub/pages/foundations/icons/overview.tsx
+++ b/showcases/patternhub/pages/foundations/icons/overview.tsx
@@ -1,14 +1,14 @@
 import DefaultPage from '../../../components/default-page';
 
-const IconOverview = () => {
-	return (
-		<DefaultPage>
-			<h1>Icon overview</h1>
-			<p>
-				Please use the [icon overview](https://design-system.deutschebahn.com/documentation/icons/) within our main documentation.
-			</p>
-		</DefaultPage>
-	);
-};
+const IconOverview = () => (
+	<DefaultPage>
+		<h1>Icon overview</h1>
+		<p>
+			Please use the [icon
+			overview](https://design-system.deutschebahn.com/documentation/icons/)
+			within our main documentation.
+		</p>
+	</DefaultPage>
+);
 
 export default IconOverview;


### PR DESCRIPTION
## Proposed changes

Adds a `corepack use pnpm@latest` step to the `99-audit-fix-dependabot.yml` workflow so that Dependabot's audit-fix job updates pnpm itself (via corepack) before running `pnpm audit --fix=update`. This ensures the lockfile is always processed with the latest pnpm version, avoiding potential compatibility issues when Dependabot commits lockfile changes.

## Checklist

### Code Quality

- [x] I have reviewed my own code (self-review), including the screen- and snapshots
- [x] I have reviewed my changes locally with an AI assistant (e.g. GitHub Copilot, Kiro, etc.)
- [x] No hardcoded values, magic numbers, or debug code left in

### Validation

- [ ] ~~I have added/updated tests that cover my changes~~ (CI workflow change — no unit tests applicable)
- [ ] ~~I have tested across all relevant frameworks (React, Angular, Vue) if applicable~~ (not applicable)

### General

- [x] The PR title follows the conventional commits format (e.g. `feat:`, `fix:`, `chore:`), as in [Git Commit Conventions](docs/conventions.md#git-commits-conventions)
- [ ] ~~If architecture, structure, or conventions changed inside a `packages/*` folder, the corresponding `AGENTS.md` has been updated~~ (not applicable)
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/chore-corepack-for-pnpm-update>

<!-- DBUX-TEST-URL-END -->