### PR TITLE
fix(drawer): icon was renamed from `account` to `person` previously

### DIFF
--- a/packages/components/src/components/drawer/examples/header.example.lite.tsx
+++ b/packages/components/src/components/drawer/examples/header.example.lite.tsx
@@ -50,7 +50,7 @@ export default function DrawerHeader() {
 					header={
 						<DBDrawerHeader
 							closeButtonText="Close"
-							startSlot={<DBIcon icon="account" />}>
+							startSlot={<DBIcon icon="person" />}>
 							With start slot
 						</DBDrawerHeader>
 					}>


### PR DESCRIPTION
## Proposed changes

The icon `account` has been renamed to `person` a while ago.

## Checklist

### Code Quality

- [x] I have reviewed my own code (self-review), including the screen- and snapshots
- [ ] I have reviewed my changes locally with an AI assistant (e.g. GitHub Copilot, Kiro, etc.)
- [x] No hardcoded values, magic numbers, or debug code left in

### Validation

- [ ] ~I have added/updated tests that cover my changes~
- [ ] ~I have tested across all relevant frameworks (React, Angular, Vue) if applicable~

### General

- [x] The PR title follows the conventional commits format (e.g. `feat:`, `fix:`, `chore:`), as in [Git Commit Conventions](docs/conventions.md#git-commits-conventions)
- [ ] If architecture, structure, or conventions changed inside a `packages/*` folder, the corresponding `AGENTS.md` has been updated
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/fix-drawer-icon-was-renamed-from-account-to-person-previously>

<!-- DBUX-TEST-URL-END -->