### PR TITLE
fix: resolve uncontrolled to controlled input warning in DBCustomSelect search

### DIFF
--- a/.changeset/fix-custom-select-search-controlled.md
+++ b/.changeset/fix-custom-select-search-controlled.md
@@ -1,0 +1,9 @@
+---
+"@db-ux/core-components": patch
+"@db-ux/ngx-core-components": patch
+"@db-ux/react-core-components": patch
+"@db-ux/wc-core-components": patch
+"@db-ux/v-core-components": patch
+---
+
+fix: resolve uncontrolled to controlled input warning in DBCustomSelect search field

--- a/.changeset/fix-custom-select-search-controlled.md
+++ b/.changeset/fix-custom-select-search-controlled.md
@@ -1,9 +1,8 @@
 ---
-"@db-ux/core-components": patch
 "@db-ux/ngx-core-components": patch
 "@db-ux/react-core-components": patch
 "@db-ux/wc-core-components": patch
 "@db-ux/v-core-components": patch
 ---
 
-fix: resolve uncontrolled to controlled input warning in DBCustomSelect search field
+fix(DBCustomSelect): initialize search value as empty string instead of undefined

--- a/packages/components/scripts/post-build/components.ts
+++ b/packages/components/scripts/post-build/components.ts
@@ -101,7 +101,8 @@ export const getComponents = (): Component[] => [
 				propsPassingFilter: [
 					'onOptionSelected',
 					'onAmountChange',
-					'onDropdownToggle'
+					'onDropdownToggle',
+					'onSearch'
 				],
 				containsFragmentMap: true
 			}

--- a/packages/components/src/components/custom-select/custom-select.lite.tsx
+++ b/packages/components/src/components/custom-select/custom-select.lite.tsx
@@ -133,7 +133,7 @@ export default function DBCustomSelect(props: DBCustomSelectProps) {
 				state.handleAutoPlacement();
 			}
 		},
-		_searchValue: undefined,
+		_searchValue: '',
 		hasValidState: () => {
 			return !!(props.validMessage ?? props.validation === 'valid');
 		},
@@ -858,7 +858,7 @@ export default function DBCustomSelect(props: DBCustomSelectProps) {
 	}, [props.options]);
 
 	onUpdate(() => {
-		state._searchValue = props.searchValue;
+		state._searchValue = props.searchValue ?? '';
 		if (props.searchValue) {
 			const sValue = props.searchValue!; // <- workaround for Angular
 			state.handleSearch(sValue);


### PR DESCRIPTION
## Proposed changes

Fixes the React warning "A component is changing an uncontrolled input to be controlled" when using the search field in `DBCustomSelect`.

The root cause was that `_searchValue` was initialized as `undefined`, making the search input uncontrolled. When a user typed, the value switched to a string, triggering React's controlled/uncontrolled warning.

Changes:
- Initialize `_searchValue` as `''` instead of `undefined` so the input is always controlled
- Use nullish coalescing (`?? ''`) when syncing `props.searchValue` to prevent reverting to `undefined`
- Add `onSearch` to `propsPassingFilter` so the event propagates correctly in framework outputs

resolves #6779

## Checklist

### Code Quality

- [x] I have reviewed my own code (self-review), including the screen- and snapshots
- [x] I have reviewed my changes locally with an AI assistant (e.g. GitHub Copilot, Kiro, etc.)
- [x] No hardcoded values, magic numbers, or debug code left in

### Validation

- [ ] I have added/updated tests that cover my changes
- [x] I have tested across all relevant frameworks (React, Angular, Vue) if applicable

### General

- [x] The PR title follows the conventional commits format (e.g. `feat:`, `fix:`, `chore:`), as in [Git Commit Conventions](docs/conventions.md#git-commits-conventions)
- [ ] If architecture, structure, or conventions changed inside a `packages/*` folder, the corresponding `AGENTS.md` has been updated
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/fix-custom-select-search-controlled>

<!-- DBUX-TEST-URL-END -->