### PR TITLE
fix(storybook): group heading stories under DBHeading

### DIFF
--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -255,6 +255,15 @@ Stories are generated from the `examples/` folder via the `configs/plugins/story
 - `configs/plugins/storybook/get-stories.cjs` — builds individual story exports
 - `configs/plugins/storybook/storybook-plugin.cjs` — main Mitosis plugin entry
 
+### Sidebar category vs. reference component
+
+The sidebar category (`title: 'Components/<category>/<storybookTitle>'`) and the reference component are separate values — do not couple them.
+
+- **Category** defaults to the component folder name (`heading` -> `DBHeading`) and is overridable per example via `storybookCategory`. The default keeps level, size or variant components of one family in a single category (`DBHeadingH1`–`DBHeadingH6` all appear under `Components/DBHeading`). Override it when a folder also ships a component that is not a variant of that family — `heading/examples/slots.example.lite.tsx` sets `storybookCategory: 'DBCustomHeading'`.
+- **Reference component** is `storybookComponentName`, defaulting to the same folder-derived name. It drives `component:`, the `@components` import and the `Props` type, so it must be an actual export. `heading` has no `DBHeading` export, which is why every heading example names one explicitly.
+
+`storybookComponentNames` picks the component per story inside one example file — see `docs/creating-examples.md`.
+
 ## Model Convention: Always keep `DefaultProps` and `DefaultState`
 
 Every component's `model.ts` **must** export a `DB[ComponentName]DefaultProps` and `DB[ComponentName]DefaultState` type, even if they are empty (`{}`). This ensures consistency across all components and makes it straightforward to add default values later without restructuring the type hierarchy.

--- a/packages/components/configs/plugins/storybook/get-meta-object.cjs
+++ b/packages/components/configs/plugins/storybook/get-meta-object.cjs
@@ -59,12 +59,20 @@ const getFnArgs = (argTypes) => {
  * @param {Object} params - Parameters object
  * @param {string} params.target - Target framework (react, angular, vue)
  * @param {string} params.componentName - Component name
+ * @param {string} params.category - Sidebar category name
  * @param {string} params.name - Story name
  * @param {Object} params.meta - Metadata object
  * @param {Array<string>} params.allImports - All imports
  * @returns {string} Generated meta object code
  */
-const getMetaObject = ({ target, componentName, name, meta, allImports }) => {
+const getMetaObject = ({
+	target,
+	componentName,
+	category,
+	name,
+	meta,
+	allImports
+}) => {
 	const { title, argTypes } = extractMetadata(target, name, meta);
 	const filteredImports = allImports?.filter((imp) => imp !== componentName);
 
@@ -91,7 +99,7 @@ const getMetaObject = ({ target, componentName, name, meta, allImports }) => {
 
 	return `
 const meta: Meta<${metaType}> = {
-	title: 'Components/${componentName}/${title}',
+	title: 'Components/${category}/${title}',
 	component: ${componentName},
 	${decorators}
 	parameters: {

--- a/packages/components/configs/plugins/storybook/storybook-plugin.cjs
+++ b/packages/components/configs/plugins/storybook/storybook-plugin.cjs
@@ -18,9 +18,19 @@ module.exports = () => ({
 			const targetMapItem = targetMapping[target].storyBookLib;
 
 			const componentNameLowercase = path.split('/')[2];
+			const folderComponentName = `DB${toPascalCase(componentNameLowercase)}`;
+			// The sidebar category defaults to the component folder, so that level or
+			// size variants of one component group together (heading -> DBHeadingH1..H6
+			// all live under DBHeading). Folders that also ship a distinct component
+			// override it via `storybookCategory` to get their own category.
+			const category =
+				meta?.useMetadata?.storybookCategory ?? folderComponentName;
+			// The reference component used for `component:`, the `@components` import
+			// and the Props type. Folders without a matching default export have to
+			// name one explicitly via `storybookComponentName`.
 			const componentName =
 				meta?.useMetadata?.storybookComponentName ??
-				`DB${toPascalCase(componentNameLowercase)}`;
+				folderComponentName;
 
 			const { allImports } = resolveImports(imports);
 			const dataImports = resolveDataImports(imports);
@@ -69,6 +79,7 @@ module.exports = () => ({
 				getMetaObject({
 					target,
 					componentName,
+					category,
 					name,
 					meta,
 					allImports

--- a/packages/components/docs/creating-examples.md
+++ b/packages/components/docs/creating-examples.md
@@ -43,6 +43,35 @@ The `useMetadata` hook configures how the example appears in Storybook:
 - **`storybookArgTypes`**: Reference to the arg types object from `_<component>.arg.types.ts`
 - **`storybookIgnore`**: Set to `true` to exclude the entire example from Storybook
 - **`storybookOverwriteArgs`**: Override default arg values for Storybook controls
+- **`storybookComponentName`**: The reference component of the example — used for `component:`, the `@components` import and the `Props` type. Defaults to `DB<PascalCase folder name>`; only set it when that default is not an actual export.
+- **`storybookComponentNames`**: Array with the component per variant, for examples that mix several components (matches the order of `storybookNames`). Defaults to `storybookComponentName` for every variant.
+- **`storybookCategory`**: The sidebar category the example is filed under (`Components/<category>/<storybookTitle>`). Defaults to `DB<PascalCase folder name>`.
+
+Category and reference component are independent. A folder with several exports keeps its variants in one category and only breaks out components that are not variants of the same family:
+
+```tsx
+// heading/examples/as-size.example.lite.tsx
+// No storybookCategory -> Components/DBHeading/Semantic and visual decoupling
+useMetadata({
+	storybookTitle: "Semantic and visual decoupling",
+	storybookComponentName: "DBHeadingH2",
+	storybookComponentNames: ["DBHeadingH6", "DBHeadingH2"],
+	storybookNames: ["h6 rendered at 2xl", "h2 rendered at 3xs"],
+	storybookArgTypes: StorybookHeadingArgTypes
+});
+```
+
+```tsx
+// heading/examples/slots.example.lite.tsx
+// DBCustomHeading is its own component -> Components/DBCustomHeading/Start and end slot
+useMetadata({
+	storybookTitle: "Start and end slot",
+	storybookCategory: "DBCustomHeading",
+	storybookComponentName: "DBCustomHeading",
+	storybookNames: ["End slot with a badge", "Both slots with an action"],
+	storybookArgTypes: StorybookHeadingArgTypes
+});
+```
 
 Example with overwrite:
 

--- a/packages/components/src/components/heading/examples/slots.example.lite.tsx
+++ b/packages/components/src/components/heading/examples/slots.example.lite.tsx
@@ -7,6 +7,9 @@ import { StorybookHeadingArgTypes } from './_heading.arg.types';
 
 useMetadata({
 	storybookTitle: 'Start and end slot',
+	// DBCustomHeading is a component of its own, not a level variant, so it gets
+	// its own sidebar category instead of the folder default DBHeading.
+	storybookCategory: 'DBCustomHeading',
 	storybookComponentName: 'DBCustomHeading',
 	storybookComponentNames: ['DBCustomHeading', 'DBCustomHeading'],
 	storybookNames: ['End slot with a badge', 'Both slots with an action'],


### PR DESCRIPTION
## Proposed changes

### Problem

All heading stories were filed under the sidebar category **`DBHeadingH2`** instead of `DBHeading`.

The cause is that one value did two jobs. In `configs/plugins/storybook/storybook-plugin.cjs`, `componentName` fed the sidebar category **and** the story's reference component at the same time:

```js
const componentName =
    meta?.useMetadata?.storybookComponentName ??
    `DB${toPascalCase(componentNameLowercase)}`;
```

It ends up in `title: 'Components/${componentName}/${title}'`, in `component:`, in the `@components` import and in the `Meta<…>` type. The `heading` folder exports `DBHeadingH1`–`DBHeadingH6` and `DBCustomHeading`, but no `DBHeading` — so the folder-derived fallback would produce a broken import and an unresolvable `DBHeadingProps` type. Every heading example therefore had to set `storybookComponentName: 'DBHeadingH2'` to name a valid reference component, and that choice dragged the category along with it.

The category was misleading on top of being wrong: examples like _Visual sizes_, _Density_ or _Logical alignment_ apply to all six levels, with H2 only being an arbitrary stand-in.

### Fix

Category and reference component are now independent values, both defaulting to the folder-derived name:

```js
const folderComponentName = `DB${toPascalCase(componentNameLowercase)}`;
const category = meta?.useMetadata?.storybookCategory ?? folderComponentName;
const componentName = meta?.useMetadata?.storybookComponentName ?? folderComponentName;
```

- `category` is used only for the `title`, so level variants of one family group together.
- `componentName` keeps driving `component:`, the import and the Props type, so it still has to be a real export.
- The new `storybookCategory` metadata lets a folder break out a component that is not a variant of that family. `heading/examples/slots.example.lite.tsx` sets `storybookCategory: 'DBCustomHeading'`.

`attribute-forwarding.example.lite.tsx` stays under `DBHeading` on purpose: it contrasts the native and the wrapper forwarding behaviour side by side, so it reads as one example rather than two.

### Result

Generated titles (identical across React, Vue and Angular):

```text
Components/DBCustomHeading/Start and end slot
Components/DBHeading/Density
Components/DBHeading/Font weight
Components/DBHeading/Forwarded heading attributes
Components/DBHeading/Logical alignment
Components/DBHeading/Paragraph spacing
Components/DBHeading/Semantic and visual decoupling
Components/DBHeading/Semantic levels and default mapping
Components/DBHeading/Visual sizes
```

No other component uses `storybookComponentName`, so every remaining story title is unchanged — for them the category was already folder-derived.

### Notes

- **No changeset**: only the Storybook generator config, example metadata and docs are touched. None of it reaches package consumers.
- **Docs**: `packages/components/AGENTS.md` gains a "Sidebar category vs. reference component" section; `docs/creating-examples.md` now documents `storybookCategory`, `storybookComponentName` and `storybookComponentNames`, which were previously undocumented.
- **Verified**: `pnpm run build` and `pnpm run test` (47 test files) pass; stories regenerated via `pnpm --filter=@db-ux/core-components run generate:stories` and titles checked for all three frameworks.

## Checklist

### Code Quality

- [x] I have reviewed my own code (self-review), including the screen- and snapshots
- [x] I have reviewed my changes locally with an AI assistant (e.g. GitHub Copilot, Kiro, etc.)
- [x] No hardcoded values, magic numbers, or debug code left in

### Validation

- [ ] I have added/updated tests that cover my changes
- [x] I have tested across all relevant frameworks (React, Angular, Vue) if applicable

### General

- [x] The PR title follows the conventional commits format (e.g. `feat:`, `fix:`, `chore:`), as in [Git Commit Conventions](docs/conventions.md#git-commits-conventions)
- [x] If architecture, structure, or conventions changed inside a `packages/*` folder, the corresponding `AGENTS.md` has been updated
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/fix-storybook-heading-category>

<!-- DBUX-TEST-URL-END -->