### PR TITLE
fix(DBControlPanelDesktop): declare explicit action for onExpandButtonTooltipFn

### DIFF
--- a/packages/components/src/components/control-panel-desktop/examples/_control-panel-desktop.arg.types.ts
+++ b/packages/components/src/components/control-panel-desktop/examples/_control-panel-desktop.arg.types.ts
@@ -6,5 +6,10 @@ export const StorybookControlPanelDesktopArgTypes: Record<string, InputType> = {
 	expanded: { control: 'boolean' },
 	expandButtonTooltip: { control: 'text' },
 	id: { control: 'text' },
-	autofocus: { control: 'boolean' }
+	autofocus: { control: 'boolean' },
+	// `onExpandButtonTooltipFn` matches the `^on.*` argTypesRegex, so Storybook
+	// would create an implicit action for it. The component calls it while
+	// rendering the toggle button label, which triggers SB_PREVIEW_API_0002.
+	// Declaring the action here makes the generator emit an explicit `fn()` spy.
+	onExpandButtonTooltipFn: { action: 'onExpandButtonTooltipFn' }
 };


### PR DESCRIPTION
## Proposed changes

Every `DBControlPanelDesktop` story logged a Storybook error (`SB_PREVIEW_API_0002`, "implicit action arg while rendering"), most visibly on the [Density docs page](https://design-system.deutschebahn.com/core-web/review/main/react-storybook/?path=/docs/components-dbcontrolpaneldesktop-density--docs) — but the cause sits in the story `meta`, so it affected `density`, `orientation`, `width` and `examples` alike.

**Cause:** `DBControlPanelDesktopProps` inherits `onExpandButtonTooltipFn` from `SidebarProps`. The Storybook previews set `actions: { argTypesRegex: '^on.*' }`, so Storybook created an _implicit_ action arg for it. `getToggleButtonText()` calls that prop **while rendering** the collapse button label, which is exactly the deprecated case.

**Fix:** Declare the prop as an action in `_control-panel-desktop.arg.types.ts`. The existing `getFnArgs` helper in `configs/plugins/storybook/get-meta-object.cjs` — built for precisely this purpose — then emits an explicit `fn()` spy into the story meta.

### Notes

- Verified via `pnpm --filter=@db-ux/core-components run generate:stories`: React and Vue stories now carry `args: { "onExpandButtonTooltipFn": fn() }`; Angular skips action entries by design (they would break the typed Props interface).
- No behavior change: the spy returns `undefined`, so the label still falls back to `DEFAULT_COLLAPSE` / `DEFAULT_EXPAND`.
- No changeset — the change is limited to a Storybook arg types file, which consumers never receive.
- `DBShellSubNavigation` uses the same `SidebarProps` and will need the same entry once it gets examples.

## Checklist

### Code Quality

- [x] I have reviewed my own code (self-review), including the screen- and snapshots
- [x] I have reviewed my changes locally with an AI assistant (e.g. GitHub Copilot, Kiro, etc.)
- [x] No hardcoded values, magic numbers, or debug code left in

### Validation

- [ ] I have added/updated tests that cover my changes
- [x] I have tested across all relevant frameworks (React, Angular, Vue) if applicable

### General

- [x] The PR title follows the conventional commits format (e.g. `feat:`, `fix:`, `chore:`), as in [Git Commit Conventions](docs/conventions.md#git-commits-conventions)
- [x] If architecture, structure, or conventions changed inside a `packages/*` folder, the corresponding `AGENTS.md` has been updated
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/fix-control-panel-desktop-storybook-implicit-action>

<!-- DBUX-TEST-URL-END -->