### PR TITLE
perf(ci): shallow-fetch main in init instead of full history

### DIFF
--- a/.github/workflows/00-init.yml
+++ b/.github/workflows/00-init.yml
@@ -62,7 +62,11 @@ jobs:
       - name: ⏬ Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          # Shallow checkout. The only thing in this job that needs git history is
+          # the aria-snapshot diff against main (see "Should Test a11y" below), and
+          # that only needs main's tip, fetched shallowly in a dedicated step. A
+          # full fetch-depth: 0 pulled every ref's complete history (~3 min).
+          fetch-depth: 1
           fetch-tags: false
 
       - name: 🔄 Init Cache Default
@@ -97,6 +101,12 @@ jobs:
         run: |
           OUTPUT=$(pnpm --silent tsx scripts/github/get-playwright-version.ts)
           echo "version=$OUTPUT" >> $GITHUB_OUTPUT
+
+      # Fetch only main's tip (single commit) so `git diff origin/main` in the
+      # a11y check has a ref to compare against, without a full-history fetch.
+      - name: ⏬ Fetch main for snapshot diff
+        shell: bash
+        run: git fetch --depth=1 origin main
 
       - name: 👩 Should Test a11y
         id: ally

--- a/.github/workflows/02-e2e-showcases.yml
+++ b/.github/workflows/02-e2e-showcases.yml
@@ -9,9 +9,6 @@ on:
       showcase:
         required: true
         type: string
-      test-ally:
-        required: false
-        type: string
 
 permissions:
   actions: write

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -291,7 +291,6 @@ jobs:
     with:
       version: ${{ needs.init.outputs.playwrightVersion }}
       showcase: stencil-showcase
-      test-ally: ${{ needs.init.outputs.test-ally }}
 
   test-showcase-angular:
     uses: ./.github/workflows/02-e2e-showcases.yml
@@ -300,7 +299,6 @@ jobs:
     with:
       version: ${{ needs.init.outputs.playwrightVersion }}
       showcase: angular-showcase
-      test-ally: ${{ needs.init.outputs.test-ally }}
 
   test-showcase-react:
     uses: ./.github/workflows/02-e2e-showcases.yml
@@ -309,7 +307,6 @@ jobs:
     with:
       version: ${{ needs.init.outputs.playwrightVersion }}
       showcase: react-showcase
-      test-ally: ${{ needs.init.outputs.test-ally }}
 
   test-showcase-vue:
     uses: ./.github/workflows/02-e2e-showcases.yml
@@ -318,7 +315,6 @@ jobs:
     with:
       version: ${{ needs.init.outputs.playwrightVersion }}
       showcase: vue-showcase
-      test-ally: ${{ needs.init.outputs.test-ally }}
 
   test-showcase-patternhub:
     uses: ./.github/workflows/02-e2e-patternhub.yml


### PR DESCRIPTION
## Proposed changes

Two related CI changes to the `init` job.

**1. Shallow-fetch main instead of full history.** `init` checked out with `fetch-depth: 0`, pulling the complete history of every ref (~3 min). The only step needing history is the aria-snapshot diff (`git diff origin/main` in `scripts/github/snapshot-changes/check-main-aria.ts`) — name, playwright-version, changeset and fork checks all use the Actions context, not git. Switched to `fetch-depth: 1` plus a dedicated `git fetch --depth=1 origin main`.

For this gate ("did any `__snapshots__/*-aria-snapshot.yaml` change") a tip-to-tip comparison is sufficient and errs toward running the a11y screen-reader test when unsure. On `main`/release the test is already forced via the existing `github.event.pull_request == null` condition, so gating behavior is preserved.

**2. Remove dead `test-ally` plumbing.** `02-e2e-showcases.yml` declared a `test-ally` input that no step referenced, and `default.yml` passed it into all four showcase test jobs. Removed. The only real consumer of init's `test-ally` output is the `test-screen-reader` job's `if:` condition, which is untouched. No behavior change.

**Why:** removes ~3 min from `init`, which is on the critical path before the pipeline fans out.

## Checklist

### Code Quality

- [x] I have reviewed my own code (self-review), including the screen- and snapshots
- [x] I have reviewed my changes locally with an AI assistant (e.g. GitHub Copilot, Kiro, etc.)
- [x] No hardcoded values, magic numbers, or debug code left in

### Validation

- [ ] I have added/updated tests that cover my changes
- [ ] I have tested across all relevant frameworks (React, Angular, Vue) if applicable

### General

- [x] The PR title follows the conventional commits format (e.g. `feat:`, `fix:`, `chore:`), as in [Git Commit Conventions](docs/conventions.md#git-commits-conventions)
- [x] If architecture, structure, or conventions changed inside a `packages/*` folder, the corresponding `AGENTS.md` has been updated
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/perf-shallow-init-fetch>

<!-- DBUX-TEST-URL-END -->