### PR TITLE
perf(ci): trim axe-core browser matrix to 4 projects

### DIFF
--- a/showcases/playwright.axe-core.ts
+++ b/showcases/playwright.axe-core.ts
@@ -1,8 +1,23 @@
 import { type PlaywrightTestConfig } from '@playwright/test';
 import config from './playwright.config';
 
+// axe-core rule checks are engine-driven and effectively browser-independent, so
+// running them across every project is redundant. We keep chromium, firefox,
+// webkit and mobile_chrome for engine/viewport coverage but drop the two projects
+// that add cost without catching axe-core-specific issues:
+//   - chromium-highContrast: forced-colors is a visual concern, covered by the
+//     visual/aria snapshot suites, not by axe-core rules.
+//   - mobile_safari: mobile_chrome already covers the mobile viewport for axe-core.
+const EXCLUDED_AXE_CORE_PROJECTS = new Set([
+	'chromium-highContrast',
+	'mobile_safari'
+]);
+
 const axeCoreConfig: PlaywrightTestConfig = {
 	...config,
+	projects: config.projects?.filter(
+		(project) => !EXCLUDED_AXE_CORE_PROJECTS.has(project.name ?? '')
+	),
 	testMatch: '*-axe-core.spec.ts'
 };
 


### PR DESCRIPTION
## Proposed changes

Trims the browser-project matrix for the **axe-core** showcase e2e suite only.

axe-core accessibility rule checks are engine-driven and effectively browser-independent, so running them across all 6-7 projects is redundant. `showcases/playwright.axe-core.ts` now filters out two projects, keeping `chromium`, `firefox`, `webkit`, `mobile_chrome`:

- **`chromium-highContrast`** — forced-colors is a visual concern, covered by the visual/aria snapshot suites, not by axe-core rules.
- **`mobile_safari`** — `mobile_chrome` already covers the mobile viewport for axe-core.

Scoped to the axe-core config only; the e2e/aria/visual/a11y-checker suites keep the full project matrix. Filtering is by project name, so stencil (which already omits `mobile_safari` in the base config) stays correct.

**Why:** axe-core was the heaviest showcase e2e suite (~231s/shard on baseline run `34454854684`), running 37 spec files across every project with a single CI worker. Cutting its project count by a third to a half reduces that directly, with no added runners.

**Note on the alternative:** raising Playwright `workers` on CI was considered and rejected — Playwright's [CI docs](https://playwright.dev/docs/ci#workers) recommend `workers: 1` for stability and warn that exceeding the runner core count causes timeouts/flakiness, and hosted `ubuntu-24.04` runners are 2-core anyway.

## Checklist

### Code Quality

- [x] I have reviewed my own code (self-review), including the screen- and snapshots
- [x] I have reviewed my changes locally with an AI assistant (e.g. GitHub Copilot, Kiro, etc.)
- [x] No hardcoded values, magic numbers, or debug code left in

### Validation

- [ ] I have added/updated tests that cover my changes
- [ ] I have tested across all relevant frameworks (React, Angular, Vue) if applicable

### General

- [x] The PR title follows the conventional commits format (e.g. `feat:`, `fix:`, `chore:`), as in [Git Commit Conventions](docs/conventions.md#git-commits-conventions)
- [x] If architecture, structure, or conventions changed inside a `packages/*` folder, the corresponding `AGENTS.md` has been updated
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/perf-e2e-matrix-rightsize>

<!-- DBUX-TEST-URL-END -->