### PR TITLE
test(ci): set Playwright workers to 50% on CI

### DIFF
--- a/showcases/playwright.config.ts
+++ b/showcases/playwright.config.ts
@@ -67,8 +67,14 @@ const config: PlaywrightTestConfig = {
 	fullyParallel: true,
 	/* Fail the build on CI if you accidentally left test.only in the source code. */
 	forbidOnly: Boolean(process.env.CI),
-	/* Opt out of parallel tests on CI. */
-	workers: process.env.CI ? 1 : undefined,
+	/*
+	 * EXPERIMENT: use half the runner's cores on CI instead of a single worker,
+	 * to measure whether parallelism speeds up the showcase e2e suites. Playwright
+	 * recommends workers: 1 on CI for stability, and standard hosted ubuntu runners
+	 * are 2-core (so '50%' == 1 there); the interesting case is the Playwright
+	 * container jobs if they have more cores. Watch the run for timeouts/flakiness.
+	 */
+	workers: process.env.CI ? '50%' : undefined,
 	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
 	reporter: process.env.CI ? 'blob' : [['list'], ['html', { open: 'never' }]],
 	/* Configure projects for major browsers */

--- a/showcases/playwright.config.ts
+++ b/showcases/playwright.config.ts
@@ -71,7 +71,7 @@ const config: PlaywrightTestConfig = {
 	 * EXPERIMENT: use half the runner's cores on CI instead of a single worker,
 	 * to measure whether parallelism speeds up the showcase e2e suites. Playwright
 	 * recommends workers: 1 on CI for stability, and standard hosted ubuntu runners
-	 * are 2-core (so '50%' == 1 there); the interesting case is the Playwright
+	 * are 4-core (so '50%' == 2 there); the interesting case is the Playwright
 	 * container jobs if they have more cores. Watch the run for timeouts/flakiness.
 	 */
 	workers: process.env.CI ? '50%' : undefined,


### PR DESCRIPTION
## Proposed changes

**Experiment / measurement PR** — sets Playwright `workers` to `'50%'` on CI (was `1`) in the shared showcase config.

Correcting an earlier assumption: standard **public-repo** `ubuntu-24.04` runners have **4 CPUs**, so `'50%'` resolves to **2 workers**, not 1. This branch exists to measure whether parallelizing the showcase e2e suites within each shard actually speeds them up vs. the current single-worker setup.

**Safety:**
- The showcase `webServer` is a read-only static file server, so concurrent workers don't collide.
- `retries: 1` (in the showcase config) absorbs any parallelism-induced flakiness.
- Playwright's docs recommend `workers: 1` for stability, so the point of this PR is to **check the run for timeouts/flakiness** before deciding whether to keep it.

Not intended to merge as-is until we've reviewed the timing delta and confirmed no new flakiness.

## Checklist

### Code Quality

- [x] I have reviewed my own code (self-review), including the screen- and snapshots
- [x] I have reviewed my changes locally with an AI assistant (e.g. GitHub Copilot, Kiro, etc.)
- [x] No hardcoded values, magic numbers, or debug code left in

### Validation

- [ ] I have added/updated tests that cover my changes
- [ ] I have tested across all relevant frameworks (React, Angular, Vue) if applicable

### General

- [x] The PR title follows the conventional commits format (e.g. `feat:`, `fix:`, `chore:`), as in [Git Commit Conventions](docs/conventions.md#git-commits-conventions)
- [x] If architecture, structure, or conventions changed inside a `packages/*` folder, the corresponding `AGENTS.md` has been updated
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/test-playwright-workers-50>

<!-- DBUX-TEST-URL-END -->