### PR TITLE
refactor(eslint-plugin): use `context.sourceCode` instead of deprecated `getSourceCode()`

### DIFF
--- a/packages/eslint-plugin/src/rules/button/button-no-text-requires-tooltip.ts
+++ b/packages/eslint-plugin/src/rules/button/button-no-text-requires-tooltip.ts
@@ -51,8 +51,7 @@ export default {
 					loc,
 					messageId: MESSAGE_IDS.BUTTON_NO_TEXT_MISSING_TOOLTIP,
 					fix(fixer: any) {
-						const sourceCode =
-							context.sourceCode || context.getSourceCode();
+						const { sourceCode } = context;
 						const text = sourceCode.getText();
 						const startOffset = node.sourceSpan.start.offset;
 						const endOffset = node.sourceSpan.end.offset;

--- a/packages/eslint-plugin/src/shared/utils.ts
+++ b/packages/eslint-plugin/src/shared/utils.ts
@@ -206,7 +206,7 @@ export function defineTemplateBodyVisitor(
 	templateVisitor: any,
 	scriptVisitor?: any
 ) {
-	const sourceCode = context.sourceCode || context.getSourceCode();
+	const { sourceCode } = context;
 
 	// Vue templates
 	if (sourceCode.parserServices?.defineTemplateBodyVisitor) {
@@ -239,7 +239,7 @@ export function createAngularVisitors(
 	componentName: string,
 	handler: (node: any, parserServices: any) => void
 ) {
-	const sourceCode = context.sourceCode || context.getSourceCode();
+	const { sourceCode } = context;
 	const parserServices = sourceCode?.parserServices;
 	const isAngular = parserServices?.convertNodeSourceSpanToLoc;
 
@@ -277,7 +277,7 @@ export function createAngularFix(
 	node: any,
 	attributeText: string
 ) {
-	const sourceCode = context.sourceCode || context.getSourceCode();
+	const { sourceCode } = context;
 	const text = sourceCode.getText();
 	const startOffset = node.sourceSpan.start.offset;
 	const endOffset = node.sourceSpan.end.offset;


### PR DESCRIPTION
## Proposed changes

Drops the deprecated `context.getSourceCode()` fallback in the ESLint plugin in favour of `context.sourceCode`. The four affected callsites used the pattern `context.sourceCode || context.getSourceCode()`, where the second branch was dead code.

**Why now:** While reviewing the `@typescript-eslint/*` 8.69.0 → 8.70.0 bump ([release notes](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v8.70.0)), I confirmed the update itself needs no code change — it only adds one opt-in rule and false-positive fixes. This cleanup is an adjacent, independent improvement surfaced during that review and is intentionally kept out of the dependency-bump PR to keep both focused.

**Why it's safe:** The plugin's `peerDependencies` declares `eslint >=9.0.0`. `context.sourceCode` has been the stable accessor since ESLint 8.40 and is always defined in ESLint 9+, while `context.getSourceCode()` is deprecated ([ESLint deprecations tracking issue](https://github.com/eslint/eslint/issues/16999), formalised in the [ESLint 9.0.0 migration guide](https://eslint.org/docs/latest/use/migrate-to-9.0.0)). So the fallback could never execute.

### Changed files

- `packages/eslint-plugin/src/shared/utils.ts` — 3 callsites (`defineTemplateBodyVisitor`, `createAngularVisitors`, `createAngularFix`)
- `packages/eslint-plugin/src/rules/button/button-no-text-requires-tooltip.ts` — 1 callsite

### Testing

- `pnpm --filter=@db-ux/core-eslint-plugin run build` — passes (`tsc` clean)
- `pnpm --filter=@db-ux/core-eslint-plugin run test` — 332/332 pass, including the React/Vue/Angular framework integration tests that exercise all four callsites

No changeset: internal-only change, no consumer-facing behaviour or public API impact.

## Checklist

### Code Quality

- [x] I have reviewed my own code (self-review), including the screen- and snapshots
- [x] I have reviewed my changes locally with an AI assistant (e.g. GitHub Copilot, Kiro, etc.)
- [x] No hardcoded values, magic numbers, or debug code left in

### Validation

- [ ] ~I have added/updated tests that cover my changes~
- [ ] ~I have tested across all relevant frameworks (React, Angular, Vue) if applicable~

### General

- [x] The PR title follows the conventional commits format (e.g. `feat:`, `fix:`, `chore:`), as in [Git Commit Conventions](docs/conventions.md#git-commits-conventions)
- [ ] If architecture, structure, or conventions changed inside a `packages/*` folder, the corresponding `AGENTS.md` has been updated
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/refactor-eslint-plugin-source-code-accessor>

<!-- DBUX-TEST-URL-END -->