### PR TITLE
test(ci): set Playwright workers to 75% on CI

### DIFF
--- a/showcases/playwright.config.ts
+++ b/showcases/playwright.config.ts
@@ -67,8 +67,15 @@ const config: PlaywrightTestConfig = {
 	fullyParallel: true,
 	/* Fail the build on CI if you accidentally left test.only in the source code. */
 	forbidOnly: Boolean(process.env.CI),
-	/* Opt out of parallel tests on CI. */
-	workers: process.env.CI ? 1 : undefined,
+	/*
+	 * EXPERIMENT: 75% of the runner's cores on CI (= 3 workers on the 4-core
+	 * public ubuntu runners). Compare against the 50%/2-worker run: 1->2 workers
+	 * roughly halved the suites, but 2->3 leaves only one core for the OS, the
+	 * static webServer and the browser processes, so the gain may be small or
+	 * negative and flakiness/timeouts may rise. retries: 1 absorbs the occasional
+	 * blip; watch whether retries eat the savings.
+	 */
+	workers: process.env.CI ? '75%' : undefined,
 	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
 	reporter: process.env.CI ? 'blob' : [['list'], ['html', { open: 'never' }]],
 	/* Configure projects for major browsers */


### PR DESCRIPTION
## Proposed changes

**Experiment / measurement PR** — follow-up to the `50%` workers run (#8093), which roughly halved the showcase e2e suites (e.g. react-showcase shard axe-core 3m42s -> 1m53s).

Sets Playwright `workers: '75%'` on CI = **3 workers** on the 4-core public `ubuntu-24.04` runners.

**Open question this measures:** 1->2 workers gained ~2x because a full core was idle. 2->3 leaves only one core for the OS, the static `webServer`, and the (multi-process, CPU-hungry) browsers, so the extra worker may give little, break even, or regress with timeouts. `retries: 1` absorbs the odd blip — the thing to watch is whether **retry counts rise** and eat the savings, and whether snapshot tests get flaky.

Compare shard timings and retries against the `50%` run before deciding which to keep. Not intended to merge as-is.

## Checklist

### Code Quality

- [x] I have reviewed my own code (self-review), including the screen- and snapshots
- [x] I have reviewed my changes locally with an AI assistant (e.g. GitHub Copilot, Kiro, etc.)
- [x] No hardcoded values, magic numbers, or debug code left in

### Validation

- [ ] I have added/updated tests that cover my changes
- [ ] I have tested across all relevant frameworks (React, Angular, Vue) if applicable

### General

- [x] The PR title follows the conventional commits format (e.g. `feat:`, `fix:`, `chore:`), as in [Git Commit Conventions](docs/conventions.md#git-commits-conventions)
- [x] If architecture, structure, or conventions changed inside a `packages/*` folder, the corresponding `AGENTS.md` has been updated
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/test-playwright-workers-75>

<!-- DBUX-TEST-URL-END -->