### PR TITLE
fix(renovate): remove schedule-window gate so scheduled runs always open PRs

### DIFF
--- a/.config/cspellignorewords.txt
+++ b/.config/cspellignorewords.txt
@@ -257,3 +257,4 @@ pnpms
 renovatebot
 drilldown
 Drilldown
+deconflict

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,5 @@
 {
 	"extends": ["config:recommended", ":disableDependencyDashboard"],
-	"timezone": "Europe/Berlin",
-	"schedule": ["after 10:00pm and before 11:00pm"],
-	"updateNotScheduled": false,
 	"branchPrefix": "renovate-",
 	"branchNameStrict": true,
 	"enabledManagers": ["npm", "nvm"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,8 @@
 {
 	"extends": ["config:recommended", ":disableDependencyDashboard"],
 	"timezone": "Europe/Berlin",
-	"schedule": ["after 9:00pm and before 11:59pm"],
+	"schedule": ["after 10:15pm and before 11:00pm"],
+	"updateNotScheduled": false,
 	"branchPrefix": "renovate-",
 	"branchNameStrict": true,
 	"enabledManagers": ["npm", "nvm"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
 	"extends": ["config:recommended", ":disableDependencyDashboard"],
 	"timezone": "Europe/Berlin",
-	"schedule": ["after 10:15pm and before 11:00pm"],
+	"schedule": ["after 10:00pm and before 11:00pm"],
 	"updateNotScheduled": false,
 	"branchPrefix": "renovate-",
 	"branchNameStrict": true,

--- a/.github/workflows/99-renovate.yml
+++ b/.github/workflows/99-renovate.yml
@@ -9,19 +9,22 @@
 # Everything else stays with Dependabot, see `.github/dependabot.yml`.
 # Scope and grouping live in `.github/renovate.json`.
 #
-# Schedule: a single daily cron at 20:00 UTC (22:00 Berlin in CEST, 21:00 in
+# Schedule: a single daily cron at 20:17 UTC (22:17 Berlin in CEST, 21:17 in
 # CET). Both are ahead of the Dependabot window at 23:00 Berlin, so pnpm lands
-# first and Dependabot PRs rebase onto it. The GitHub Actions cron is the only
-# scheduling gate -- Renovate has no internal `schedule` in
-# `.github/renovate.json`, so every invocation is free to create PRs and there is
-# no window it can drift out of. A single cron line (rather than one per DST
-# offset) keeps it to one run per day without any no-op gate.
+# first and Dependabot PRs rebase onto it. The minute is deliberately off the top
+# of the hour: GitHub warns that scheduled jobs starting at :00 sit in the
+# busiest queue and may be dropped entirely under load, which no config on our
+# side can recover from. The GitHub Actions cron is the only scheduling gate --
+# Renovate has no internal `schedule` in `.github/renovate.json`, so every
+# invocation is free to create PRs and there is no window it can drift out of. A
+# single cron line (rather than one per DST offset) keeps it to one run per day
+# without any no-op gate.
 
 name: Renovate
 
 on:
   schedule:
-    - cron: "0 20 * * *" # 22:00 Berlin (CEST) / 21:00 Berlin (CET)
+    - cron: "17 20 * * *" # 22:17 Berlin (CEST) / 21:17 Berlin (CET)
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/99-renovate.yml
+++ b/.github/workflows/99-renovate.yml
@@ -10,15 +10,16 @@
 # Scope and grouping live in `.github/renovate.json`.
 #
 # Schedule: daily 22:30 Europe/Berlin, i.e. ahead of the Dependabot window at
-# 23:00. GitHub cron only knows UTC, so both possible DST offsets are triggered:
-# during CEST (UTC+2) the "30 20" line fires at 22:30 Berlin, during CET (UTC+1)
-# the "30 21" line does. The respective other line fires an hour off (21:30 or
-# 23:30 Berlin). Renovate's own `schedule` (evaluated in `timezone:
-# Europe/Berlin`, see `.github/renovate.json`) must therefore span a window wide
-# enough to cover both offsets plus Renovate's own ~1-2 min startup drift --
-# otherwise the invocation lands outside the window and Renovate skips branch/PR
-# creation as a no-op. The window "after 9:00pm and before 11:59pm" covers the
-# 21:30 and 23:30 edges as well as the on-time 22:30 run.
+# 23:00, so pnpm lands first and Dependabot PRs rebase onto it. GitHub cron only
+# knows UTC, so both possible DST offsets are triggered: during CEST (UTC+2) the
+# "30 20" line fires at 22:30 Berlin, during CET (UTC+1) the "30 21" line does.
+# The respective other line fires an hour off (23:30 during CEST, 21:30 during
+# CET). Renovate's own `schedule` (evaluated in `timezone: Europe/Berlin`, see
+# `.github/renovate.json`) gates those off-DST invocations to a no-op: its window
+# is centred on 22:30 -- wide enough to absorb Renovate's ~1-2 min startup drift,
+# narrow enough to exclude both 21:30 and 23:30. Keeping 23:30 out matters: a
+# summer run at 23:30 would otherwise create/update PRs after Dependabot's 23:00
+# window and reverse the intended ordering.
 # A manual `workflow_dispatch` run drops that gate via `RENOVATE_FORCE`.
 
 name: Renovate

--- a/.github/workflows/99-renovate.yml
+++ b/.github/workflows/99-renovate.yml
@@ -9,25 +9,19 @@
 # Everything else stays with Dependabot, see `.github/dependabot.yml`.
 # Scope and grouping live in `.github/renovate.json`.
 #
-# Schedule: daily 22:30 Europe/Berlin, i.e. ahead of the Dependabot window at
-# 23:00, so pnpm lands first and Dependabot PRs rebase onto it. GitHub cron only
-# knows UTC, so both possible DST offsets are triggered: during CEST (UTC+2) the
-# "30 20" line fires at 22:30 Berlin, during CET (UTC+1) the "30 21" line does.
-# The respective other line fires an hour off (23:30 during CEST, 21:30 during
-# CET). Renovate's own `schedule` (evaluated in `timezone: Europe/Berlin`, see
-# `.github/renovate.json`) gates those off-DST invocations to a no-op: its window
-# is centred on 22:30 -- wide enough to absorb Renovate's ~1-2 min startup drift,
-# narrow enough to exclude both 21:30 and 23:30. Keeping 23:30 out matters: a
-# summer run at 23:30 would otherwise create/update PRs after Dependabot's 23:00
-# window and reverse the intended ordering.
-# A manual `workflow_dispatch` run drops that gate via `RENOVATE_FORCE`.
+# Schedule: a single daily cron at 20:00 UTC (22:00 Berlin in CEST, 21:00 in
+# CET). Both are ahead of the Dependabot window at 23:00 Berlin, so pnpm lands
+# first and Dependabot PRs rebase onto it. The GitHub Actions cron is the only
+# scheduling gate -- Renovate has no internal `schedule` in
+# `.github/renovate.json`, so every invocation is free to create PRs and there is
+# no window it can drift out of. A single cron line (rather than one per DST
+# offset) keeps it to one run per day without any no-op gate.
 
 name: Renovate
 
 on:
   schedule:
-    - cron: "30 20 * * *" # 22:30 Berlin during CEST (UTC+2)
-    - cron: "30 21 * * *" # 22:30 Berlin during CET (UTC+1)
+    - cron: "0 20 * * *" # 22:00 Berlin (CEST) / 21:00 Berlin (CET)
   workflow_dispatch:
 
 permissions: {}
@@ -61,4 +55,3 @@ jobs:
           # lookup during platform init, whose transient failures abort the
           # whole run with "Initialization error: Authentication failure".
           RENOVATE_USERNAME: "${{ steps.generate-token.outputs.app-slug }}[bot]"
-          RENOVATE_FORCE: ${{ github.event_name == 'workflow_dispatch' && '{"schedule":null}' || '{}' }}

--- a/docs/adr/adr-03-dependency-automation.md
+++ b/docs/adr/adr-03-dependency-automation.md
@@ -6,7 +6,7 @@ To reduce the amount of time spent updating dependencies we want to use an autom
 
 We pick [dependabot](https://github.com/dependabot) because it is the default for open-source GitHub projects.
 
-**Amendment:** Dependabot remains the primary tool. A narrowly scoped, self-hosted [Renovate](https://github.com/renovatebot/renovate) run was added for the gaps Dependabot does not cover: Node version defined in `.nvmrc`, the `packageManager` (pnpm) version and the `@db-ux/db-theme*` packages (manually triggered, without the need to check for all other dependencies). See [Dependency Update Strategy](../dependency-update-strategy.md#renovate-for-pnpm-and-the-db-theme-packages).
+**Amendment:** Dependabot remains the primary tool. A narrowly scoped, self-hosted [Renovate](https://github.com/renovatebot/renovate) run was added for the gaps Dependabot does not cover: Node version defined in `.nvmrc`, the `packageManager` (pnpm) version and the `@db-ux/db-theme*` packages (manually triggered, without the need to check for all other dependencies). See [Dependency Update Strategy](../dependency-update-strategy.md#renovate-for-the-node-version-pnpm-and-the-db-theme-packages).
 
 ## Problem description and context
 

--- a/docs/dependency-update-strategy.md
+++ b/docs/dependency-update-strategy.md
@@ -173,17 +173,17 @@ Workspace packages reference the catalog in their `devDependencies`:
 2. Delete stale `tsconfig.tsbuildinfo` files in the affected package.
 3. Verify with `pnpm --filter <package> run build`.
 
-## Renovate for pnpm and the DB theme packages
+## Renovate for the Node version, pnpm and the DB theme packages
 
-Dependabot handles everything **except** three cases, which are covered by a self-hosted Renovate run ([`.github/workflows/99-renovate.yml`](../.github/workflows/99-renovate.yml), scope in [`.github/renovate.json`](../.github/renovate.json)):
+Dependabot handles everything **except** three cases, which are covered by a self-hosted Renovate run ([`.github/workflows/99-renovate.yml`](../.github/workflows/99-renovate.yml), scope in [`.github/renovate.json`](../.github/renovate.json)). The scope is limited to two managers (`"enabledManagers": ["npm", "nvm"]`) and everything else is disabled, so these are the only updates Renovate opens:
 
 | Covered by Renovate                            | Why not Dependabot                                                                                                                                                                                                                                                                        |
 | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `.nvmrc` (Node version)                        | Dependabot does not update the Node version, so the Node version used both locally and in CI isn't controlled at all (besides Major level)                                                                                                                                                |
+| `.nvmrc` (Node version)                        | Dependabot does not update `.nvmrc` at all, so the Node version used both locally and in CI would otherwise only ever change by hand. Renovate keeps it current via the `nvm` manager (`matchManagers: ["nvm"]`).                                                                         |
 | `packageManager` (the pnpm version + its hash) | Dependabot does not update the `packageManager` field, so the pnpm version used by CI and Corepack drifts and has to be bumped by hand                                                                                                                                                    |
 | `@db-ux/db-theme*`                             | Theme releases should land as one reviewable PR across all manifests (including the vite-plugin test fixtures, which are outside the pnpm workspace and therefore invisible to Dependabot); plus we'd like to trigger this manually, without the need to check for all other dependencies |
 
-The latter is ignored in `.github/dependabot.yml` so the two bots never open competing PRs (`pnpm` version isn't even supported by `dependabot`). Everything else is disabled in the Renovate config (`matchPackageNames: ["*"], enabled: false`) — if you want a new dependency automated, add it to Dependabot, not to Renovate.
+The two bots never open competing PRs. For the Node version and pnpm there is nothing to deconflict, because Dependabot updates neither `.nvmrc` nor the `packageManager` field in the first place. Only the theme packages are npm dependencies Dependabot _would_ pick up, so they are explicitly ignored in `.github/dependabot.yml` (`dependency-name: "@db-ux/db-theme*"`). On the Renovate side everything else is disabled (`matchPackageNames: ["*"], enabled: false`) — if you want a new dependency automated, add it to Dependabot, not to Renovate.
 
 ### `ignorePaths` has to be spelled out
 
@@ -193,9 +193,9 @@ Watch out for one consequence: the fixtures are plain npm projects with `file:` 
 
 ### Scheduling
 
-The workflow runs daily at **22:30 Europe/Berlin**, ahead of the Dependabot window at 23:00, so a pnpm lands first and Dependabot's PRs are rebased onto it instead of the other way around. It can also be started manually via _Run workflow_ (`workflow_dispatch`). GitHub cron expressions are UTC-only, so the workflow triggers at both possible offsets (20:30 and 21:30 UTC) and Renovate's own `schedule` — evaluated in `Europe/Berlin` — turns the out-of-window invocation into a no-op.
+The workflow runs daily via a single GitHub Actions cron at **20:00 UTC** (22:00 Europe/Berlin in CEST, 21:00 in CET). Both are ahead of the Dependabot window at 23:00 Berlin, so a pnpm bump lands first and Dependabot's PRs are rebased onto it instead of the other way around. It can also be started manually via _Run workflow_ (`workflow_dispatch`).
 
-That second part needs one non-default option: `schedule` on its own only gates **branch creation**, while `updateNotScheduled` defaults to `true`, which lets an out-of-window run rebase existing Renovate branches and retrigger their pipelines at the wrong hour. The config therefore sets `"updateNotScheduled": false`. A manual run bypasses the whole gate through `RENOVATE_FORCE`.
+The GitHub Actions cron is the **only** scheduling gate. Renovate deliberately has no internal `schedule` in `.github/renovate.json`: an internal window is evaluated after the container starts, so image-pull and init drift (~1–2 min) could push the invocation past the window and turn the run into a no-op that never opens PRs. Letting the cron decide _when_ and Renovate always act removes that failure mode. A single cron line (rather than one per DST offset) keeps it to one run per day.
 
 ### Branches, commits and PRs
 

--- a/docs/dependency-update-strategy.md
+++ b/docs/dependency-update-strategy.md
@@ -193,7 +193,7 @@ Watch out for one consequence: the fixtures are plain npm projects with `file:` 
 
 ### Scheduling
 
-The workflow runs daily via a single GitHub Actions cron at **20:00 UTC** (22:00 Europe/Berlin in CEST, 21:00 in CET). Both are ahead of the Dependabot window at 23:00 Berlin, so a pnpm bump lands first and Dependabot's PRs are rebased onto it instead of the other way around. It can also be started manually via _Run workflow_ (`workflow_dispatch`).
+The workflow runs daily via a single GitHub Actions cron at **20:17 UTC** (22:17 Europe/Berlin in CEST, 21:17 in CET). Both are ahead of the Dependabot window at 23:00 Berlin, so a pnpm bump lands first and Dependabot's PRs are rebased onto it instead of the other way around. The minute is deliberately off `:00`: GitHub warns that jobs scheduled at the top of the hour sit in the busiest queue and can be dropped under load. It can also be started manually via _Run workflow_ (`workflow_dispatch`).
 
 The GitHub Actions cron is the **only** scheduling gate. Renovate deliberately has no internal `schedule` in `.github/renovate.json`: an internal window is evaluated after the container starts, so image-pull and init drift (~1–2 min) could push the invocation past the window and turn the run into a no-op that never opens PRs. Letting the cron decide _when_ and Renovate always act removes that failure mode. A single cron line (rather than one per DST offset) keeps it to one run per day.
 


### PR DESCRIPTION
## Proposed changes

Scheduled Renovate runs never opened PRs on their own; only manual
`workflow_dispatch` runs did. The scheduled invocation created the app token
and started Renovate but produced no branches or PRs.

**Root cause — the internal schedule window, not permissions.** Renovate's
internal `schedule` in `.github/renovate.json` was a narrow time window
(originally `"* 22 * * *"`, 22:00–22:59 Berlin). Renovate evaluates that window
*after* the container starts, and image-pull + init drift (~1–2 min) plus the
DST double-cron pushed the scheduled invocation outside the window — so Renovate
treated the run as a no-op and created nothing. Manual runs were unaffected
because `RENOVATE_FORCE: '{"schedule":null}'` bypassed the window.

**Change — let the GitHub Actions cron be the only scheduling gate.** Since the
exact update time doesn't matter, the internal window adds nothing but the
failure mode above, so it's removed entirely:

- `renovate.json`: dropped `schedule`, `updateNotScheduled`, and the now-orphaned
  `timezone`. Every invocation is now free to create PRs — there is no window to
  drift out of.
- `99-renovate.yml`: collapsed the two DST cron lines into a single
  `0 20 * * *` (20:00 UTC → 22:00 Berlin in CEST, 21:00 in CET). One run per day,
  always ahead of Dependabot's 23:00 Berlin window, so the "pnpm lands first,
  Dependabot rebases onto it" ordering still holds. Removed the now-dead
  `RENOVATE_FORCE` env var (its only job was overriding the internal window) and
  rewrote the header comment.
- `docs/dependency-update-strategy.md`: updated the Scheduling section to
  describe the single-cron / no-internal-schedule design and the drift rationale.

Trade-off: Renovate can no longer target a precise Berlin minute. That's
acceptable here — timing is irrelevant, and this is the simplest design that
guarantees a scheduled run can't silently open zero PRs.

CI scheduling only — no consumer-facing package code changed, so no changeset.

## Checklist

### Code Quality

- [x] I have reviewed my own code (self-review), including the screen- and snapshots
- [x] I have reviewed my changes locally with an AI assistant (e.g. GitHub Copilot, Kiro, etc.)
- [x] No hardcoded values, magic numbers, or debug code left in

### Validation

- [ ] I have added/updated tests that cover my changes
- [ ] I have tested across all relevant frameworks (React, Angular, Vue) if applicable

### General

- [x] The PR title follows the conventional commits format (e.g. `feat:`, `fix:`, `chore:`), as in [Git Commit Conventions](docs/conventions.md#git-commits-conventions)
- [ ] If architecture, structure, or conventions changed inside a `packages/*` folder, the corresponding `AGENTS.md` has been updated
<!-- DBUX-TEST-URL-START -->


🔭🐙🐈 Test this branch here: <https://design-system.deutschebahn.com/core-web/review/fix-renovate-config>

<!-- DBUX-TEST-URL-END -->